### PR TITLE
Support experimental Explore UI

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -25,6 +25,7 @@ export class Browser {
   async render(options) {
     let browser;
     let page;
+    let exploreHandle;
     const env = Object.assign({}, process.env);
 
     try {
@@ -53,7 +54,8 @@ export class Browser {
       // wait for all panels to render
       await page.waitForFunction(() => {
         const panelCount = document.querySelectorAll('.panel').length;
-        return (<any>window).panelsRendered >= panelCount;
+        const exploreCount = document.querySelectorAll('.explore-graph > canvas').length;
+        return exploreCount > 0 || ((<any>window).panelsRendered >= panelCount);
       }, {
         timeout: options.timeout * 1000
       });
@@ -62,7 +64,12 @@ export class Browser {
         options.filePath = uniqueFilename(os.tmpdir()) + '.png';
       }
 
-      await page.screenshot({path: options.filePath});
+      exploreHandle = await page.$('.explore-container .panel-container:first-of-type');
+      if (exploreHandle != null) {
+        await exploreHandle.screenshot({path: options.filePath});
+      } else {
+        await page.screenshot({path: options.filePath});
+      }
 
       return { filePath: options.filePath };
 


### PR DESCRIPTION
The Explore UI is in beta for Grafana 5.3.1. I thought it would be
nice if we could support arbitrary PNG rendering for any explore query.

We accomplish this by basically looking for a rendered canvas (because
the Explore UI doesn't emit the same events as a rendered dashboard).

Then, since there is no solo mode for explore panels, we render the
graph element instead.