### PR TITLE
Wait until all network connections to be idle before rendering

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -66,7 +66,8 @@ export class Browser {
         'domain': options.domain,
       });
 
-      await page.goto(options.url);
+      // wait until all data was loaded
+      await page.goto(options.url, { waitUntil: 'networkidle0' });
 
       // wait for all panels to render
       await page.waitForFunction(() => {


### PR DESCRIPTION
Consider using waitUntil in page.goto to fix empty pngs

Sometimes 'load' event fires before query data is fetched, and page.waitForFunction bit doesn't help with that. This fix uses puppeteer's 'networkidle0' event, which ensures there is no active network requests for 500ms.