### PR TITLE
Updated the panelCount query in the page.waitForFunction()

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -70,7 +70,7 @@ export class Browser {
 
       // wait for all panels to render
       await page.waitForFunction(() => {
-        const panelCount = document.querySelectorAll('.panel').length;
+        const panelCount = document.querySelectorAll('.panel').length || document.querySelectorAll('.panel-container').length;
         return (<any>window).panelsRendered >= panelCount;
       }, {
         timeout: options.timeout * 1000


### PR DESCRIPTION
When using grafana-image-renderer with [Grafana 6.3.3](https://github.com/grafana/grafana/releases/tag/v6.3.3) I was getting several dashboards that were rendering with empty panels. Upon inspection of the page, I realized that there is not a '.panel' class applied to the panels any more. 

I added `|| document.querySelectorAll('.panel-container').length` to line 73 to account for this change. 

I have not done any rigorous testing, but it did solve my problem.

I am using grafana-image-renderer as a docker image.