### PR TITLE
Docker: Updates dependencies to remove vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   && apk --no-cache  upgrade \
   && apk add --no-cache --virtual .build-deps \
     udev ttf-opensans chromium \
-		ca-certificates dumb-init \
+		ca-certificates dumb-init curl nghttp2 openldap \
   && rm -rf /var/cache/apk/* /tmp/*
 
 FROM base as build


### PR DESCRIPTION
**Before update:**
```bash
> docker run --rm -v $HOME/.cache:/root/.cache/ aquasec/trivy --clear-cache grafana/grafana-image-renderer:latest                                                                                                                             
2019-11-18T22:24:46.663Z        INFO    Removing image caches...                                                                                                                                                                              
2019-11-18T22:24:46.668Z        INFO    Updating vulnerability database...                                                                                                                                                                    
2019-11-18T22:25:04.827Z        INFO    Detecting Alpine vulnerabilities...                                                                                                                                                                   
2019-11-18T22:25:04.834Z        INFO    Updating yarn Security DB...                                                                                                                                                                          
2019-11-18T22:25:06.067Z        INFO    Detecting yarn vulnerabilities...                                                                                                                                                                     

grafana/grafana-image-renderer:latest (alpine 3.9.4)
====================================================
Total: 12 (UNKNOWN: 0, LOW: 2, MEDIUM: 6, HIGH: 4, CRITICAL: 0)

+----------+------------------+----------+-------------------+---------------+--------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| curl     | CVE-2019-5482    | HIGH     | 7.64.0-r2         | 7.64.0-r3     | curl: heap buffer overflow in  |
|          |                  |          |                   |               | function tftp_receive_packet() |
+          +------------------+          +                   +               +--------------------------------+
|          | CVE-2019-5481    |          |                   |               | curl: double free due to       |
|          |                  |          |                   |               | subsequent call of realloc()   |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| expat    | CVE-2019-15903   | MEDIUM   | 2.2.7-r0          | 2.2.7-r1      | expat: heap-based buffer       |
|          |                  |          |                   |               | over-read via crafted XML      |
|          |                  |          |                   |               | input                          |
+----------+------------------+          +-------------------+---------------+--------------------------------+
| libxslt  | CVE-2019-18197   |          | 1.1.33-r1         | 1.1.33-r2     | libxslt: use after             |
|          |                  |          |                   |               | free in xsltCopyText in        |
|          |                  |          |                   |               | transform.c leads to password  |
|          |                  |          |                   |               | disclosure...                  |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| nghttp2  | CVE-2019-9511    | HIGH     | 1.35.1-r0         | 1.35.1-r1     | HTTP/2: large amount of data   |
|          |                  |          |                   |               | requests leads to denial of    |
|          |                  |          |                   |               | service                        |
+          +------------------+          +                   +               +--------------------------------+
|          | CVE-2019-9513    |          |                   |               | HTTP/2: flood using PRIORITY   |
|          |                  |          |                   |               | frames results in excessive    |
|          |                  |          |                   |               | resource consumption           |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| openldap | CVE-2019-13565   | MEDIUM   | 2.4.47-r2         | 2.4.48-r0     | openldap: ACL restrictions     |
|          |                  |          |                   |               | bypass due to sasl_ssf value   |
|          |                  |          |                   |               | being set permanently          |
+          +------------------+----------+                   +               +--------------------------------+
|          | CVE-2019-13057   | LOW      |                   |               | openldap: Information          |
|          |                  |          |                   |               | disclosure issue in slapd      |
|          |                  |          |                   |               | component                      |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| openssl  | CVE-2019-1549    | MEDIUM   | 1.1.1c-r1         | 1.1.1d-r0     | openssl: information           |
|          |                  |          |                   |               | disclosure in fork()           |
+          +------------------+          +                   +               +--------------------------------+
|          | CVE-2019-1563    |          |                   |               | openssl: information           |
|          |                  |          |                   |               | disclosure in PKCS7_dataDecode |
|          |                  |          |                   |               | and CMS_decrypt_set1_pkey      |
+          +------------------+----------+                   +               +--------------------------------+
|          | CVE-2019-1547    | LOW      |                   |               | openssl: side-channel weak     |
|          |                  |          |                   |               | encryption vulnerability       |
+----------+------------------+----------+-------------------+---------------+--------------------------------+
| tiff     | CVE-2019-10927   | MEDIUM   | 4.0.10-r1         | 4.0.10-r2     | A vulnerability has been       |
|          |                  |          |                   |               | identified in SCALANCE SC-600  |
|          |                  |          |                   |               | (V2.0), SCALANCE XB-200        |
|          |                  |          |                   |               | (V4.1),...                     |
+----------+------------------+----------+-------------------+---------------+--------------------------------+

```

**After update:**
```bash
> docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.cache:/root/.cache/ aquasec/trivy --clear-cache grafana/grafana-image-renderer:dev                                   
2019-11-18T22:15:10.200Z        INFO    Removing image caches...                                                                                                                              
2019-11-18T22:15:10.262Z        INFO    Updating vulnerability database...                                                                                                                    
2019-11-18T22:15:18.926Z        INFO    Detecting Alpine vulnerabilities...                                                                                                                   
                                                                                                                                                                                              
grafana/grafana-image-renderer:dev (alpine 3.9.4)                                                                                                                                             
=================================================                                                                                                                                             
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0) 
```