### PR TITLE
Docker: Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
   echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-  apk --no-cache update && \
   apk --no-cache upgrade && \
   apk add --no-cache udev ttf-opensans chromium ca-certificates dumb-init nghttp2 openldap curl && \
   apk del nghttp2 openldap curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 WORKDIR /usr/src/app
 
 RUN \
-  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-  && apk --no-cache  update \
-  && apk --no-cache  upgrade \
-  && apk add --no-cache --virtual .build-deps \
-    udev ttf-opensans chromium \
-		ca-certificates dumb-init curl nghttp2 openldap \
-  && rm -rf /var/cache/apk/* /tmp/*
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+  apk --no-cache update && \
+  apk --no-cache upgrade && \
+  apk add --no-cache udev ttf-opensans chromium ca-certificates dumb-init nghttp2 openldap curl && \
+  apk del nghttp2 openldap curl && \
+  rm -rf /tmp/*
 
 FROM base as build
 


### PR DESCRIPTION
Based on https://github.com/grafana/grafana-image-renderer/pull/53#issuecomment-556344273 cleaning up the Dockerfile. Note: The only way I could properly remove nghttp2 openldap curl packages was to first install them, not sure if there are any easier/better way?