### PR TITLE
Ignore https errors using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ for rendering and using remote rendering, see [Remote Rendering Using Docker](#r
 
 If you still want to install the plugin in the Grafana docker image we provide instructions for how to build a custom Grafana image, see [Grafana Docker documentation](https://grafana.com/docs/installation/docker/#custom-image-with-grafana-image-renderer-plugin-pre-installed) for further instructions.
 
+### Environment variables
+
+You can override certain settings by using environment variables and make sure that those are available for the Grafana process.
+
+**Ignore HTTPS errors:**
+
+Instruct headless Chrome Whether to ignore HTTPS errors during navigation. Per default HTTPS errors is not ignored.
+Due to the security risk it's not recommended to ignore HTTPS errors.
+
+```bash
+export GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS=true
+```
+
+**Custom Chrome/Chromium path:**
+
+if you already have Chrome or Chromium installed on your system you can configure Grafana Image renderer plugin to use this instead of the pre-packaged version of Chromium.
+
+Please note that this is not recommended since you may encounter problems if the installed version of Chrome/Chromium is not is compatible with the Grafana Image renderer plugin.
+
+```bash
+export GF_RENDERER_PLUGIN_CHROME_BIN=/some/custom/chrome/bin
+```
+
 ## Remote Rendering Using Docker
 
 Instead of installing and running the image renderer as a plugin, you can run it as a remote image rendering service using Docker. Read more about [remote rendering using Docker](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you still want to install the plugin in the Grafana docker image we provide i
 
 ### Environment variables
 
-You can override certain settings by using environment variables and make sure that those are available for the Grafana process.
+You can override certain settings by using environment variables and making sure that those are available for the Grafana process.
 
 **Ignore HTTPS errors:**
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,6 @@ Due to the security risk it's not recommended to ignore HTTPS errors.
 export GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS=true
 ```
 
-**Custom Chrome/Chromium path:**
-
-if you already have Chrome or Chromium installed on your system you can configure Grafana Image renderer plugin to use this instead of the pre-packaged version of Chromium.
-
-Please note that this is not recommended since you may encounter problems if the installed version of Chrome/Chromium is not is compatible with the Grafana Image renderer plugin.
-
-```bash
-export GF_RENDERER_PLUGIN_CHROME_BIN=/some/custom/chrome/bin
-```
-
 ## Remote Rendering Using Docker
 
 Instead of installing and running the image renderer as a plugin, you can run it as a remote image rendering service using Docker. Read more about [remote rendering using Docker](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md).

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -17,16 +17,6 @@ Due to the security risk it's not recommended to ignore HTTPS errors.
 export IGNORE_HTTPS_ERRORS=true
 ```
 
-**Custom Chrome/Chromium path:**
-
-if you already have Chrome or Chromium installed on your system you can configure Grafana Image renderer plugin to use this instead of the pre-packaged version of Chromium.
-
-Please note that this is not recommended since you may encounter problems if the installed version of Chrome/Chromium is not is compatible with the Grafana Image renderer plugin.
-
-```bash
-export CHROME_BIN=/some/custom/chrome/bin
-```
-
 ## Docker Compose example
 
 The following docker-compose example can also be found in [docker/](https://github.com/grafana/grafana-image-renderer/tree/master/docker).

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -4,6 +4,29 @@ As an alternative to installing and running the image renderer as a plugin you c
 
 The docker image are published at [Docker Hub](https://hub.docker.com/r/grafana/grafana-image-renderer).
 
+## Environment variables
+
+You can override certain settings by using environment variables and make sure that those are available for the Grafana process.
+
+**Ignore HTTPS errors:**
+
+Instruct headless Chrome Whether to ignore HTTPS errors during navigation. Per default HTTPS errors is not ignored.
+Due to the security risk it's not recommended to ignore HTTPS errors.
+
+```bash
+export IGNORE_HTTPS_ERRORS=true
+```
+
+**Custom Chrome/Chromium path:**
+
+if you already have Chrome or Chromium installed on your system you can configure Grafana Image renderer plugin to use this instead of the pre-packaged version of Chromium.
+
+Please note that this is not recommended since you may encounter problems if the installed version of Chrome/Chromium is not is compatible with the Grafana Image renderer plugin.
+
+```bash
+export CHROME_BIN=/some/custom/chrome/bin
+```
+
 ## Docker Compose example
 
 The following docker-compose example can also be found in [docker/](https://github.com/grafana/grafana-image-renderer/tree/master/docker).

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -6,7 +6,7 @@ The docker image are published at [Docker Hub](https://hub.docker.com/r/grafana/
 
 ## Environment variables
 
-You can override certain settings by using environment variables and make sure that those are available for the Grafana process.
+You can override certain settings by using environment variables and making sure that those are available for the Grafana process.
 
 **Ignore HTTPS errors:**
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,8 +6,13 @@ import uniqueFilename = require('unique-filename');
 
 export function newPluginBrowser(log: Logger): Browser {
   const env = Object.assign({}, process.env);
-  let chromeBin: any;
+  let ignoreHttpsErrors = false;
 
+  if (env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS']) {
+    ignoreHttpsErrors = env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS'] === 'true';
+  }
+
+  let chromeBin: any;
   if (env['GF_RENDERER_PLUGIN_CHROME_BIN']) {
     chromeBin = env['GF_RENDERER_PLUGIN_CHROME_BIN'];
   } else if ((process as any).pkg) {
@@ -19,24 +24,31 @@ export function newPluginBrowser(log: Logger): Browser {
     chromeBin = [path.dirname(process.execPath), ...parts].join(path.sep);
   }
 
-  return new Browser(log, chromeBin);
+  return new Browser(log, ignoreHttpsErrors, chromeBin);
 }
 
 export function newServerBrowser(log: Logger): Browser {
   const env = Object.assign({}, process.env);
-  let chromeBin: any;
+  let ignoreHttpsErrors = false;
 
+  if (env['IGNORE_HTTPS_ERRORS']) {
+    ignoreHttpsErrors = env['IGNORE_HTTPS_ERRORS'] === 'true';
+  }
+
+  let chromeBin: any;
   if (env['CHROME_BIN']) {
     chromeBin = env['CHROME_BIN'];
   }
 
-  return new Browser(log, chromeBin);
+  return new Browser(log, ignoreHttpsErrors, chromeBin);
 }
 
 export class Browser {
   chromeBin?: string;
+  ignoreHttpsErrors: boolean;
 
-  constructor(private log: Logger, chromeBin?: string) {
+  constructor(private log: Logger, ignoreHttpsErrors: boolean, chromeBin?: string) {
+    this.ignoreHttpsErrors = ignoreHttpsErrors;
     this.chromeBin = chromeBin;
   }
 
@@ -67,6 +79,7 @@ export class Browser {
 
       let launcherOptions: any = {
         env: env,
+        ignoreHttpsErrors: this.ignoreHttpsErrors,
         args: ['--no-sandbox'],
       };
 

--- a/src/grpc-plugin.ts
+++ b/src/grpc-plugin.ts
@@ -28,9 +28,15 @@ export class GrpcPlugin {
     console.log(`1|1|tcp|${SERVER_ADDRESS}|grpc`);
 
     if (this.browser.chromeBin) {
-      this.log.info('Renderer plugin started', 'chromeBin', this.browser.chromeBin);
+      this.log.info(
+        'Renderer plugin started',
+        'chromeBin',
+        this.browser.chromeBin,
+        'ignoreHttpsErrors',
+        this.browser.ignoreHttpsErrors
+      );
     } else {
-      this.log.info('Renderer plugin started');
+      this.log.info('Renderer plugin started', 'ignoreHttpsErrors', this.browser.ignoreHttpsErrors);
     }
   }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -27,6 +27,10 @@ export class HttpServer {
       this.log.info(`Using chromeBin ${this.browser.chromeBin}`);
     }
 
+    if (this.browser.ignoreHttpsErrors) {
+      this.log.info(`Ignoring HTTPS errors`);
+    }
+
     this.app.listen(this.options.port);
     this.log.info(`HTTP Server started, listening on ${this.options.port}`);
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,11 +34,11 @@ export class PluginLogger {
     }
 
     if (optionalParams) {
-      for (let n = 0; n < optionalParams.length; n = n + 2) {
+      for (let n = 0; n < optionalParams.length; n += 2) {
         const key = optionalParams[n];
         const value = optionalParams[n + 1];
 
-        if (key && value) {
+        if (key !== null && value !== null) {
           logEntry[key] = value;
         }
       }


### PR DESCRIPTION
Makes it possible to configure puppeteer with `ignoreHttpsErrors` when launching chrome, see https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions. 

Fixes #33 