### PR TITLE
Provide correctly named config parameter to Chromium when overriding to skip https errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7 (2019-12-03)
+
+- Provide correctly named config parameter to Chromium when overriding to skip https errors using environment variable `GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS` and/or `IGNORE_HTTPS_ERRORS`.
+
 ## 1.0.6 (2019-11-25)
 
 - Wait until all network connections to be idle before rendering [#24](https://github.com/grafana/grafana-image-renderer/pull/24), [d1ff](https://github.com/d1ff)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - Wait until all network connections to be idle before rendering [#24](https://github.com/grafana/grafana-image-renderer/pull/24), [d1ff](https://github.com/d1ff)
 - Support ignoring https errors using environment variable [#59](https://github.com/grafana/grafana-image-renderer/pull/59), [marefr](https://github.com/marefr)
-- Docker: Update dependencies to remove vulnerabilities (#53)(https://github.com/grafana/grafana-image-renderer/pull/53), [marefr](https://github.com/marefr)
-- Fix typo in log statement (#39)(https://github.com/grafana/grafana-image-renderer/pull/39), [ankon](https://github.com/ankon)
+- Docker: Update dependencies to remove vulnerabilities [53](https://github.com/grafana/grafana-image-renderer/pull/53), [marefr](https://github.com/marefr)
+- Fix typo in log statement [#39](https://github.com/grafana/grafana-image-renderer/pull/39), [ankon](https://github.com/ankon)
 - Updated documentation
 
 ## 1.0.5 (2019-09-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Wait until all network connections to be idle before rendering [#24](https://github.com/grafana/grafana-image-renderer/pull/24), [d1ff](https://github.com/d1ff)
 - Support ignoring https errors using environment variable [#59](https://github.com/grafana/grafana-image-renderer/pull/59), [marefr](https://github.com/marefr)
-- Docker: Update dependencies to remove vulnerabilities [53](https://github.com/grafana/grafana-image-renderer/pull/53), [marefr](https://github.com/marefr)
+- Docker: Update dependencies to remove vulnerabilities [#53](https://github.com/grafana/grafana-image-renderer/pull/53), [marefr](https://github.com/marefr)
 - Fix typo in log statement [#39](https://github.com/grafana/grafana-image-renderer/pull/39), [ankon](https://github.com/ankon)
 - Updated documentation
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,10 +6,10 @@ import uniqueFilename = require('unique-filename');
 
 export function newPluginBrowser(log: Logger): Browser {
   const env = Object.assign({}, process.env);
-  let ignoreHttpsErrors = false;
+  let ignoreHTTPSErrors = false;
 
   if (env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS']) {
-    ignoreHttpsErrors = env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS'] === 'true';
+    ignoreHTTPSErrors = env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS'] === 'true';
   }
 
   let chromeBin: any;
@@ -24,15 +24,15 @@ export function newPluginBrowser(log: Logger): Browser {
     chromeBin = [path.dirname(process.execPath), ...parts].join(path.sep);
   }
 
-  return new Browser(log, ignoreHttpsErrors, chromeBin);
+  return new Browser(log, ignoreHTTPSErrors, chromeBin);
 }
 
 export function newServerBrowser(log: Logger): Browser {
   const env = Object.assign({}, process.env);
-  let ignoreHttpsErrors = false;
+  let ignoreHTTPSErrors = false;
 
   if (env['IGNORE_HTTPS_ERRORS']) {
-    ignoreHttpsErrors = env['IGNORE_HTTPS_ERRORS'] === 'true';
+    ignoreHTTPSErrors = env['IGNORE_HTTPS_ERRORS'] === 'true';
   }
 
   let chromeBin: any;
@@ -40,15 +40,15 @@ export function newServerBrowser(log: Logger): Browser {
     chromeBin = env['CHROME_BIN'];
   }
 
-  return new Browser(log, ignoreHttpsErrors, chromeBin);
+  return new Browser(log, ignoreHTTPSErrors, chromeBin);
 }
 
 export class Browser {
   chromeBin?: string;
-  ignoreHttpsErrors: boolean;
+  ignoreHTTPSErrors: boolean;
 
-  constructor(private log: Logger, ignoreHttpsErrors: boolean, chromeBin?: string) {
-    this.ignoreHttpsErrors = ignoreHttpsErrors;
+  constructor(private log: Logger, ignoreHTTPSErrors: boolean, chromeBin?: string) {
+    this.ignoreHTTPSErrors = ignoreHTTPSErrors;
     this.chromeBin = chromeBin;
   }
 
@@ -79,7 +79,7 @@ export class Browser {
 
       let launcherOptions: any = {
         env: env,
-        ignoreHttpsErrors: this.ignoreHttpsErrors,
+        ignoreHTTPSErrors: this.ignoreHTTPSErrors,
         args: ['--no-sandbox'],
       };
 

--- a/src/grpc-plugin.ts
+++ b/src/grpc-plugin.ts
@@ -32,11 +32,11 @@ export class GrpcPlugin {
         'Renderer plugin started',
         'chromeBin',
         this.browser.chromeBin,
-        'ignoreHttpsErrors',
-        this.browser.ignoreHttpsErrors
+        'ignoreHTTPSErrors',
+        this.browser.ignoreHTTPSErrors
       );
     } else {
-      this.log.info('Renderer plugin started', 'ignoreHttpsErrors', this.browser.ignoreHttpsErrors);
+      this.log.info('Renderer plugin started', 'ignoreHttpsErrors', this.browser.ignoreHTTPSErrors);
     }
   }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -27,7 +27,7 @@ export class HttpServer {
       this.log.info(`Using chromeBin ${this.browser.chromeBin}`);
     }
 
-    if (this.browser.ignoreHttpsErrors) {
+    if (this.browser.ignoreHTTPSErrors) {
       this.log.info(`Ignoring HTTPS errors`);
     }
 


### PR DESCRIPTION
Provide correctly named config parameter to Chromium when overriding to skip https errors using environment variable `GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS` and/or `IGNORE_HTTPS_ERRORS`.