### PR TITLE
Remote rendering: Support reading config from file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ node_modules
 scripts
 .prettierignore
 .prettierrc.json
+dev.json
 Dockerfile
 Makefile
 plugin_start*

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,10 @@ FROM base
 COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/build build
 COPY --from=build /usr/src/app/proto proto
+COPY --from=build /usr/src/app/default.json config.json
 
 EXPOSE 8081
 
 ENTRYPOINT ["dumb-init", "--"]
 
-CMD ["node", "build/app.js", "server", "--port=8081"]
+CMD ["node", "build/app.js", "server", "--config=config.json"]

--- a/default.json
+++ b/default.json
@@ -1,0 +1,14 @@
+{
+  "service": {
+    "port": 8081,
+    "metrics": {
+      "enabled": false,
+      "collectDefaultMetrics": true,
+      "buckets": [0.5, 1, 3, 5, 7, 10, 20, 30, 60]
+    },
+    "rendering": {
+      "chromeBin": null,
+      "ignoresHttpsErrors": false
+    }
+  }
+}

--- a/dev.json
+++ b/dev.json
@@ -1,0 +1,14 @@
+{
+  "service": {
+    "port": 8081,
+    "metrics": {
+      "enabled": true,
+      "collectDefaultMetrics": true,
+      "buckets": [0.5, 1, 3, 5, 7, 10, 20, 30, 60]
+    },
+    "rendering": {
+      "chromeBin": null,
+      "ignoresHttpsErrors": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "prettier:check": "prettier --list-different \"**/*.ts\"",
     "prettier:write": "prettier --list-different \"**/*.ts\" --write",
     "precommit": "npm run tslint & npm run typecheck",
-    "watch": "ENABLE_METRICS=true tsc-watch --onSuccess \"node build/app.js server --port=8080\"",
+    "watch": "tsc-watch --onSuccess \"node build/app.js server --config=dev.json\"",
     "build": "tsc",
-    "start": "ENABLE_METRICS=true node build/app.js --port=8080"
+    "start": "node build/app.js --config=dev.json"
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.3",
@@ -24,6 +24,7 @@
     "express-prom-bundle": "^5.1.5",
     "google-protobuf": "3.5.0",
     "grpc": "^1.24.2",
+    "lodash": "^4.17.15",
     "minimist": "^1.2.0",
     "morgan": "^1.9.0",
     "mz": "^2.7.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,28 +1,68 @@
-import { GrpcPlugin } from './grpc-plugin';
-import { HttpServer } from './http-server';
+import * as path from 'path';
+import * as puppeteer from 'puppeteer';
+import * as _ from 'lodash';
+import { GrpcPlugin } from './plugin/grpc-plugin';
+import { HttpServer } from './service/http-server';
 import { ConsoleLogger, PluginLogger } from './logger';
-import { newPluginBrowser, newServerBrowser } from './browser';
+import { Browser } from './browser';
 import * as minimist from 'minimist';
+import { defaultPluginConfig, defaultServiceConfig, readJSONFileSync } from './config';
 
 async function main() {
   const argv = minimist(process.argv.slice(2));
+  const env = Object.assign({}, process.env);
   const command = argv._[0];
 
   if (command === undefined) {
-    const logger = new PluginLogger();
-    const browser = newPluginBrowser(logger);
-    const plugin = new GrpcPlugin(logger, browser);
-    plugin.start();
-  } else if (command === 'server') {
-    const logger = new ConsoleLogger();
+    const config = defaultPluginConfig;
 
-    if (!argv.port) {
-      logger.error('Specify http port using argument --port=5000');
-      return;
+    if (env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS']) {
+      config.rendering.ignoresHttpsErrors = env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS'] === 'true';
     }
 
-    const browser = newServerBrowser(logger);
-    const server = new HttpServer({ port: argv.port }, logger, browser);
+    if (env['GF_RENDERER_PLUGIN_CHROME_BIN']) {
+      config.rendering.chromeBin = env['GF_RENDERER_PLUGIN_CHROME_BIN'];
+    } else if ((process as any).pkg) {
+      const parts = puppeteer.executablePath().split(path.sep);
+      while (!parts[0].startsWith('chrome-')) {
+        parts.shift();
+      }
+
+      config.rendering.chromeBin = [path.dirname(process.execPath), ...parts].join(path.sep);
+    }
+
+    const logger = new PluginLogger();
+    const browser = new Browser(config.rendering, logger);
+    const plugin = new GrpcPlugin(config, logger, browser);
+    plugin.start();
+  } else if (command === 'server') {
+    let config = defaultServiceConfig;
+    const logger = new ConsoleLogger();
+
+    if (argv.config) {
+      try {
+        const fileConfig = readJSONFileSync(argv.config);
+        config = _.merge(config, fileConfig);
+      } catch (e) {
+        logger.error('failed to read config from path', argv.config, 'error', e);
+        return;
+      }
+    }
+
+    if (env['IGNORE_HTTPS_ERRORS']) {
+      config.rendering.ignoresHttpsErrors = env['IGNORE_HTTPS_ERRORS'] === 'true';
+    }
+
+    if (env['CHROME_BIN']) {
+      config.rendering.chromeBin = env['CHROME_BIN'];
+    }
+
+    if (env['ENABLE_METRICS']) {
+      config.service.metrics.enabled = env['ENABLE_METRICS'] === 'true';
+    }
+
+    const browser = new Browser(config.rendering, logger);
+    const server = new HttpServer(config, logger, browser);
 
     server.start();
   } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs';
+
+export interface RenderingConfig {
+  chromeBin?: string;
+  ignoresHttpsErrors: boolean;
+}
+
+export interface ServiceConfig {
+  service: {
+    port: number;
+
+    metrics: {
+      enabled: boolean;
+      collectDefaultMetrics: boolean;
+      buckets: number[];
+    };
+  };
+  rendering: RenderingConfig;
+}
+
+export interface PluginConfig {
+  plugin: {
+    grpc: {
+      host: string;
+      port: number;
+    };
+  };
+  rendering: RenderingConfig;
+}
+
+const defaultRenderingConfig: RenderingConfig = {
+  chromeBin: undefined,
+  ignoresHttpsErrors: false,
+};
+
+export const defaultServiceConfig: ServiceConfig = {
+  service: {
+    port: 8081,
+    metrics: {
+      enabled: false,
+      collectDefaultMetrics: true,
+      buckets: [0.5, 1, 3, 5, 7, 10, 20, 30, 60],
+    },
+  },
+  rendering: defaultRenderingConfig,
+};
+
+export const defaultPluginConfig: PluginConfig = {
+  plugin: {
+    grpc: {
+      host: '127.0.0.1',
+      port: 50059,
+    },
+  },
+  rendering: defaultRenderingConfig,
+};
+
+export const readJSONFileSync = (filePath: string): any => {
+  const rawdata = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(rawdata);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,6 +2115,11 @@ lodash.clone@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
By providing `--config=<json file>` as arg to render service (not plugin) you can now provide config from file. If existing environment variables are used they will be applied after reading in configuration from file.