### PR TITLE
Support of PDF

### DIFF
--- a/src/plugin/grpc-plugin.ts
+++ b/src/plugin/grpc-plugin.ts
@@ -78,6 +78,7 @@ export class GrpcPlugin {
       domain: req.domain,
       timezone: req.timezone,
       encoding: req.encoding,
+      jsonData: req.jsonData,
     };
 
     try {

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -52,6 +52,7 @@ export class HttpServer {
       domain: req.query.domain,
       timezone: req.query.timezone,
       encoding: req.query.encoding,
+      jsonData: req.query.jsonData,
     };
     this.log.info(`render request received for ${options.url}`);
     const result = await this.browser.render(options);


### PR DESCRIPTION
This PR extends rendering with support of PDF. The parameter 'encoding' must be set to 'pdf'.

There is a new 'jsonData' parameter which allows to inject extra parameters at different steps of the rendering process (see https://github.com/grafana/grafana/pull/21307 for support of this parameter in Grafana). 

'jsonData' is a JSON object with the following possible fields:

- launchOptions: is sent as parameter of launch method (see https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions)

Example:
`{"launchOptions":{"headless":false},"waitFor":30000}`
(can be useful to debug headless browser)

- viewport: is sent as parameter of setViewport method (see https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetviewportviewport).

Example:
`{"viewport":{"deviceScaleFactor":4}}`

- emulateMedia: parameter of https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pageemulatemediatype

- defaultNavigationTimeout: parameter of https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaultnavigationtimeouttimeout

- extraUrlParams: this string is added at the end of the Grafana URL which is called.

Example: 
`{"extraUrlParams": "&autofitpanels"}`

- styleTags: an array of strings which are passed to addStyleTag method 
https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pageaddstyletagoptions

Example:
`{"styleTags":[{"content":".sidemenu {display: none;}"}]}`
(hide left menu)

- scriptTags: an array of strings which are passed to addScriptTag method https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pageaddscripttagoptions

This could allow to inject specific Javascript but I have no use case.

- waitFor: number of milliseconds to wait after loading the page

- pdf: options passed to https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagepdfoptions

Example:
`{"pdf":{"format":"A4","printBackground":true,"scale":0.6}}`

- screenshot: options passed to https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagescreenshotoptions

Example:
`{"screenshot":{"fullPage":true}}`
(is used only for PNG/JPEG rendering)
