### PR TITLE
Add SKIP_GRPC build option to allow local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ARCH = darwin-x64-unknown
 SKIP_CHROMIUM =
 OUT =
+SKIP_GRPC =
 
 all: clean build
 
@@ -22,7 +23,7 @@ clean_package:
 	./scripts/clean_target.sh ${ARCH} ${OUT}
 
 package:
-	./scripts/package_target.sh ${ARCH} ${SKIP_CHROMIUM} ${OUT}
+	./scripts/package_target.sh ${ARCH} ${SKIP_CHROMIUM} ${OUT} ${SKIP_GRPC}
 
 archive:
 	./scripts/archive_target.sh ${ARCH} ${OUT}

--- a/docs/building_from_source.md
+++ b/docs/building_from_source.md
@@ -26,6 +26,9 @@ cd grafana-image-renderer
 
     # build and package without including Chromium
     make build_package ARCH=<ARCH> SKIP_CHROMIUM=true OUT=plugin-<ARCH>-no-chromium
+
+    # build and package without including Chromium and with local copy of grpc
+    make build_package ARCH=<ARCH> SKIP_CHROMIUM=true OUT=plugin-<ARCH>-no-chromium SKIP_GRPC=true
     ```
 
 3. Built artifacts can be found in ./artifacts directory

--- a/scripts/package_target.sh
+++ b/scripts/package_target.sh
@@ -3,6 +3,13 @@
 ARCH="${1:-}"
 SKIP_CHROMIUM=${2:-false}
 OUT="${3:-}"
+SKIP_GRPC=${4:-false}
+
+COPY_PATH=dist/plugin-${ARCH}/
+
+if [ ! -z "$OUT"  ]; then
+    COPY_PATH=dist/${OUT}
+fi
 
 if [ -z "$ARCH" ]; then
     echo "ARCH (arg 1) has to be set"
@@ -25,7 +32,12 @@ if [ $? != 0 ]; then
    echo "${?}\n". 1>&2 && exit 1
 fi
 
-node scripts/download_grpc.js ${ARCH} ${OUT}
+if [ ${SKIP_GRPC} = false ]; then
+    node scripts/download_grpc.js ${ARCH} ${OUT}
+else
+    echo "Including local copy of grpc"
+    cp ./node_modules/grpc/build/Release/grpc_node.node ${COPY_PATH}
+fi
 
 if [ $? != 0 ]; then
    echo "${?}\n". 1>&2 && exit 1
@@ -35,12 +47,6 @@ node scripts/rename_executable.js ${ARCH} ${OUT}
 
 if [ $? != 0 ]; then
    echo "${?}\n". 1>&2 && exit 1
-fi
-
-COPY_PATH=dist/plugin-${ARCH}/
-
-if [ ! -z "$OUT"  ]; then
-    COPY_PATH=dist/${OUT}
 fi
 
 cp plugin.json ${COPY_PATH}


### PR DESCRIPTION
The option allows using gprc from the local build instead of downloading
the precompiled binary.