### PR TITLE
Render image even if error alert appears

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -63,11 +63,11 @@ export class Browser {
       // wait until all data was loaded
       await page.goto(options.url, { waitUntil: 'networkidle0' });
 
-      // wait for all panels to render
+      // wait for all panels (or any alert panel) to render
       await page.waitForFunction(
         () => {
           const panelCount = document.querySelectorAll('.panel').length || document.querySelectorAll('.panel-container').length;
-          return (window as any).panelsRendered >= panelCount;
+          return ((window as any).panelsRendered >= panelCount) || (document.querySelectorAll('.alert').length > 0);
         },
         {
           timeout: options.timeout * 1000,


### PR DESCRIPTION
Prior to this PR, any error in a grafana panel will cause the waitFunction to never return, causing a timeout error. This makes debugging grafana very difficult.

This PR allows errors to be visible in the rendered screenshot