### PR TITLE
Rename default timezone env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ You can override certain settings by using environment variables and making sure
 
 **Default timezone:**
 
-Instruct headless Chrome to use a default timezone when not provided by Grafana, .e.g. when rendering panel image of alert. See [ICU’s metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
+Instruct headless Chrome to use a default timezone when not provided by Grafana, e.g. when rendering panel image of alert. See [ICU’s metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs. Fallbacks to `TZ` environment variable if not set.
 
 ```bash
-TZ=Europe/Stockholm
+GF_RENDERER_PLUGIN_TZ=Europe/Stockholm
 ```
 
 **Ignore HTTPS errors:**

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -26,10 +26,10 @@ export HTTP_PORT=0
 
 **Default timezone:**
 
-Instruct headless Chrome to use a default timezone when not provided by Grafana, .e.g. when rendering panel image of alert. See [ICU’s metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
+Instruct headless Chrome to use a default timezone when not provided by Grafana, .e.g. when rendering panel image of alert. See [ICU’s metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs. Fallbacks to `TZ` environment variable if not set.
 
 ```bash
-export TZ=Europe/Stockholm
+export BROWSER_TZ=Europe/Stockholm
 ```
 
 **Ignore HTTPS errors:**

--- a/src/app.ts
+++ b/src/app.ts
@@ -67,7 +67,9 @@ main().catch(err => {
 });
 
 function populatePluginConfigFromEnv(config: PluginConfig, env: NodeJS.ProcessEnv) {
-  if (env['TZ']) {
+  if (env['GF_RENDERER_PLUGIN_TZ']) {
+    config.rendering.timezone = env['GF_RENDERER_PLUGIN_TZ'];
+  } else {
     config.rendering.timezone = env['TZ'];
   }
 
@@ -81,7 +83,9 @@ function populatePluginConfigFromEnv(config: PluginConfig, env: NodeJS.ProcessEn
 }
 
 function populateServiceConfigFromEnv(config: ServiceConfig, env: NodeJS.ProcessEnv) {
-  if (env['TZ']) {
+  if (env['BROWSER_TZ']) {
+    config.rendering.timezone = env['BROWSER_TZ'];
+  } else {
     config.rendering.timezone = env['TZ'];
   }
 


### PR DESCRIPTION
Renames `TZ` env variables to `GF_RENDERER_PLUGIN_TZ` for plugin and `BROWSER_TZ` for service. Fallbacks to `TZ` env variable.