### PR TITLE
Plugin: Automatically assign gRPC port per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Due to the security risk it's not recommended to ignore HTTPS errors.
 GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS=true
 ```
 
+**gRPC port:**
+
+Change the listening port of the gRPC server. Default is `0` and will automatically assign a port not in use.
+
+```bash
+GF_RENDERER_PLUGIN_GRPC_PORT=50059
+```
+
 ## Remote Rendering Using Docker
 
 Instead of installing and running the image renderer as a plugin, you can run it as a remote image rendering service using Docker. Read more about [remote rendering using Docker](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md).

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,6 +73,10 @@ function populatePluginConfigFromEnv(config: PluginConfig, env: NodeJS.ProcessEn
     config.rendering.timezone = env['TZ'];
   }
 
+  if (env['GF_RENDERER_PLUGIN_GRPC_PORT']) {
+    config.plugin.grpc.port = parseInt(env['GF_RENDERER_PLUGIN_GRPC_PORT'] as string, 10);
+  }
+
   if (env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS']) {
     config.rendering.ignoresHttpsErrors = env['GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS'] === 'true';
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,7 @@ export const defaultPluginConfig: PluginConfig = {
   plugin: {
     grpc: {
       host: '127.0.0.1',
-      port: 50059,
+      port: 0,
     },
   },
   rendering: defaultRenderingConfig,

--- a/src/plugin/grpc-plugin.ts
+++ b/src/plugin/grpc-plugin.ts
@@ -55,6 +55,10 @@ export class GrpcPlugin {
     if (this.config.rendering.chromeBin) {
       this.log.info(
         'Renderer plugin started',
+        'grpcHost',
+        this.config.plugin.grpc.host,
+        'grpcPort',
+        boundPortNumber,
         'chromeBin',
         this.config.rendering.chromeBin,
         'ignoreHTTPSErrors',


### PR DESCRIPTION
Changes default grpc port from 50059 to 0 (auto assign).
Add support for env variable GF_RENDERER_PLUGIN_GRPC_PORT
to set configure grpc port.