### PR TITLE
Remote rendering: Improve error handling, logging and metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ CMD [ "yarn", "run", "dev" ]
 
 FROM base
 
+ENV NODE_ENV=production
+
 COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/build build
 COPY --from=build /usr/src/app/proto proto

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -28,6 +28,8 @@ CMD [ "yarn", "run", "dev" ]
 
 FROM base
 
+ENV NODE_ENV=production
+
 COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/build build
 COPY --from=build /usr/src/app/proto proto

--- a/src/plugin/grpc-plugin.ts
+++ b/src/plugin/grpc-plugin.ts
@@ -89,7 +89,7 @@ export class GrpcPlugin {
 
     try {
       this.log.debug('Render request received', 'url', options.url);
-      const result = await this.browser.render(options);
+      await this.browser.render(options);
       callback(null, { error: '' });
     } catch (err) {
       this.log.error('Render request failed', 'url', options.url, 'error', err.toString());

--- a/src/service/metrics_middleware.ts
+++ b/src/service/metrics_middleware.ts
@@ -17,6 +17,16 @@ export const metricsMiddleware = (config: MetricsConfig, log: Logger) => {
     buckets: config.requestDurationBuckets,
     excludeRoutes: [/^((?!(render)).)*$/],
     promClient: {},
+    formatStatusCode: res => {
+      if (res && res.req && res.req.aborted) {
+        // Nginx non-standard code 499 Client Closed Request
+        // Used when the client has closed the request before
+        // the server could send a response.
+        return 499;
+      }
+
+      return res.status_code || res.statusCode;
+    },
   } as any;
 
   if (config.collectDefaultMetrics) {


### PR DESCRIPTION
Had completely screwed up the exception handling when running as HTTP service, basically swallowed the exception and tried to log it, but the logger was badly implemented. This is the reason why metrics only showed 200 response statuses and nothing else :)

Changes:
- Service: Don't swallow exceptions and fix logging of parameters
- Metrics: Use status 499 when client close the connection
  - When Grafana cancel a render request status 499 is used for
the http_request_duration_seconds_* metrics instead of 200.
499 is a non-standard code and is used by Nginx and I think
it's okay to use this here since the code is not returned
to any client.
- Docker: Set NODE_ENV=production
  - not sure this makes any difference, but couldn't hurt
- Changed request logging to use debug level if status < 400 and error if >= 400