### PR TITLE
Renderer: add device scale support

### DIFF
--- a/proto/renderer.proto
+++ b/proto/renderer.proto
@@ -14,6 +14,7 @@ message RenderRequest {
   string renderKey = 8;
   string domain = 9;
   bool debug = 10;
+  float scale = 11;
 }
 
 message RenderResponse {

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -9,6 +9,7 @@ export interface RenderOptions {
   url: string;
   width: string | number;
   height: string | number;
+  scale: string | number;
   filePath: string;
   timeout: string | number;
   renderKey: string;
@@ -65,6 +66,7 @@ export class Browser {
   validateOptions(options: RenderOptions) {
     options.width = parseInt(options.width as string, 10) || 1000;
     options.height = parseInt(options.height as string, 10) || 500;
+    options.scale = parseFloat(options.scale as string) || 1;
     options.timeout = parseInt(options.timeout as string, 10) || 30;
 
     if (options.width > 3000 || options.width < 10) {
@@ -73,6 +75,10 @@ export class Browser {
 
     if (options.height > 3000 || options.height < 10) {
       options.height = 1500;
+    }
+
+    if (options.scale <= 0 || isNaN(options.scale) || options.scale == Infinity) {
+      options.scale = 1;
     }
   }
 
@@ -131,7 +137,7 @@ export class Browser {
     await page.setViewport({
       width: options.width,
       height: options.height,
-      deviceScaleFactor: 1,
+      deviceScaleFactor: options.scale,
     });
     await page.setCookie({
       name: 'renderKey',

--- a/src/plugin/grpc-plugin.ts
+++ b/src/plugin/grpc-plugin.ts
@@ -79,7 +79,7 @@ export class GrpcPlugin {
       url: req.url,
       width: req.width,
       height: req.height,
-      scale: (req.scale > 0 && req.scale != Infinity) ? req.scale : 1,
+      scale: req.scale,
       filePath: req.filePath,
       timeout: req.timeout,
       renderKey: req.renderKey,

--- a/src/plugin/grpc-plugin.ts
+++ b/src/plugin/grpc-plugin.ts
@@ -79,6 +79,7 @@ export class GrpcPlugin {
       url: req.url,
       width: req.width,
       height: req.height,
+      scale: (req.scale > 0 && req.scale != Infinity) ? req.scale : 1,
       filePath: req.filePath,
       timeout: req.timeout,
       renderKey: req.renderKey,

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -93,6 +93,7 @@ export class HttpServer {
       url: req.query.url,
       width: req.query.width,
       height: req.query.height,
+      scale: req.query.scale,
       filePath: req.query.filePath,
       timeout: req.query.timeout,
       renderKey: req.query.renderKey,


### PR DESCRIPTION
This pull request adds support for `scale` parameter to the renderer, through both the gRPC interface and the http interface.

For interoperability with the current version of Grafana, the missing  `scale` field will be treated as 1, so that the images can be rendered as before. 

ref: https://github.com/grafana/grafana/issues/22472