### PR TITLE
Render: Fix panel titles should not be focused when rendering

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -138,6 +138,7 @@ export class Browser {
       value: options.renderKey,
       domain: options.domain,
     });
+    await page.mouse.move(options.width, options.height);
 
     await this.timings.navigate(async () => {
       // wait until all data was loaded


### PR DESCRIPTION
Add a call to the mouse.move function so the mouse is in the bottom right corner of the viewport instead of the top left corner. 
It allows to not have the "mouse:hover" style on titles while rendering panels.

I've tested several calls to the render function and it seems not to have any other impact.

Fixes #111