### PR TITLE
Release grafana-image-renderer v2.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.0-beta1 (2020-04-22)
+
+- Adds support for Grafana v2 backend plugins [#128](https://github.com/grafana/grafana-image-renderer/pull/128), [marefr](https://github.com/marefr)
+- Browser: Adds support for setting viewport device scale factor [#128](https://github.com/grafana/grafana-image-renderer/pull/128), [marefr](https://github.com/marefr)
+- Browser: Adds support for attaching Accept-Language header to support render is name locale as Grafana user [#128](https://github.com/grafana/grafana-image-renderer/pull/128), [marefr](https://github.com/marefr)
+- Browser: Fail render if the URL has socket protocol [#127](https://github.com/grafana/grafana-image-renderer/pull/127), [aknuds1](https://github.com/aknuds1)
+- Chore: Upgrade typescript dependencies [#129](https://github.com/grafana/grafana-image-renderer/pull/129), [marefr](https://github.com/marefr)
+
 ## 1.0.12 (2020-03-31)
 
 - Remote rendering: Delete temporary file after serving it to client [#120](https://github.com/grafana/grafana-image-renderer/pull/120), [marefr](https://github.com/marefr)

--- a/plugin.json
+++ b/plugin.json
@@ -18,10 +18,10 @@
       {"name": "Project site", "url": "https://github.com/grafana/grafana-image-renderer"},
       {"name": "Apache License", "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"}
     ],
-    "version": "1.0.12",
-    "updated": "2020-03-31"
+    "version": "2.0.0-beta1",
+    "updated": "2020-04-22"
   },
   "dependencies": {
-    "grafanaVersion": "5.x 6.x"
+    "grafanaVersion": "5.x.x 6.x.x 7.x.x"
   }
 }


### PR DESCRIPTION
Planning to update documentation later for v2.0.0 stable or beta2 (#130)