### PR TITLE
Use timeout opt value for browser page.goto

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -175,7 +175,7 @@ export class Browser {
       this.log.debug('Navigating and waiting for all network requests to finish', 'url', options.url);
     }
 
-    await page.goto(options.url, { waitUntil: 'networkidle0' });
+    await page.goto(options.url, { waitUntil: 'networkidle0', timeout: options.timeout * 1000 });
 
     if (this.config.verboseLogging) {
       this.log.debug('Waiting for dashboard/panel to load', 'timeout', `${options.timeout}s`);


### PR DESCRIPTION
Fix #169
page.goto timeout needs to be aligned to query timeout in remote server mode.