### PR TITLE
Allow configuring the default browser timeout

### DIFF
--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -76,6 +76,15 @@ This can be useful to enable (`true`) when troubleshooting.
 RENDERING_DUMPIO=true
 ```
 
+**Change the browser timeout**
+
+Sets the default maximum time (in milliseconds) for the browser to perform actions like make upstream HTTP requests. Default is 30000.
+
+```bash
+RENDERING_DEFAULT_TIMEOUT=10000
+```
+
+
 **Start browser with additional arguments:**
 
 Additional arguments to pass to the headless browser instance. Default is `--no-sandbox`. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/). Multiple arguments is separated with comma-character.

--- a/src/app.ts
+++ b/src/app.ts
@@ -158,6 +158,10 @@ function populateServiceConfigFromEnv(config: ServiceConfig, env: NodeJS.Process
     config.rendering.verboseLogging = env['RENDERING_VERBOSE_LOGGING'] === 'true';
   }
 
+  if (env['RENDERING_DEFAULT_TIMEOUT']) {
+    config.rendering.defaultTimeout = parseInt(env['RENDERING_DEFAULT_TIMEOUT'] as string, 10);
+  }
+
   if (env['RENDERING_DUMPIO']) {
     config.rendering.dumpio = env['RENDERING_DUMPIO'] === 'true';
   }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -161,6 +161,9 @@ export class Browser {
       domain: options.domain,
     });
 
+    this.log.debug(`Setting default timeout`, this.config.defaultTimeout);
+    await page.setDefaultTimeout(this.config.defaultTimeout);
+
     if (options.headers && Object.keys(options.headers).length > 0) {
       this.log.debug(`Setting extra HTTP headers for page`, 'headers', options.headers);
       await page.setExtraHTTPHeaders(options.headers);

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface RenderingConfig {
   maxWidth: number;
   maxHeight: number;
   maxDeviceScaleFactor: number;
+  defaultTimeout: number;
   mode: string;
   clustering: ClusteringConfig;
   verboseLogging: boolean;
@@ -72,6 +73,7 @@ const defaultRenderingConfig: RenderingConfig = {
   maxWidth: 3000,
   maxHeight: 3000,
   maxDeviceScaleFactor: 3,
+  defaultTimeout: 30000,
   mode: 'default',
   clustering: {
     mode: 'browser',


### PR DESCRIPTION
This adds a new RENDERING_DEFAULT_TIMEOUT environment variable that sets the default page timeout for browser actions - see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagesetdefaulttimeouttimeout for what this covers.

We set the default to 30000, which is the Puppeteer default, so this won't change any existing behaviour unless the environment variable is explicitly set.