### PR TITLE
POC: Massive performance boost experiment with no full page reloads between renders

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -19,10 +19,7 @@
   },
   "rendering": {
     "chromeBin": null,
-    "args": [
-      "--no-sandbox",
-      "--disable-setuid-sandbox"
-    ],
+    "args": ["--no-sandbox", "--disable-setuid-sandbox"],
     "ignoresHttpsErrors": false,
 
     "timezone": null,
@@ -34,7 +31,7 @@
     "maxHeight": 8000,
     "maxDeviceScaleFactor": 10,
 
-    "mode": "default",
+    "mode": "reusable",
     "clustering": {
       "mode": "browser",
       "maxConcurrency": 5

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "precommit": "npm run tslint & npm run typecheck",
     "watch": "tsc-watch --onSuccess \"node build/app.js server --config=dev.json\"",
     "build": "tsc",
-    "start": "node build/app.js --config=dev.json"
+    "start": "node build/app.js server --config=dev.json"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.0",
@@ -54,10 +54,7 @@
     }
   },
   "lint-staged": {
-    "*.ts": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.ts": ["prettier --write", "git add"]
   },
   "pkg": {
     "assets": "proto/*"

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -180,32 +180,27 @@ export class Browser {
       this.log.debug('Navigating and waiting for all network requests to finish', 'url', options.url);
     }
 
-    if (!this.hasLoaded) {
-      await page.goto(options.url, { waitUntil: 'networkidle0' });
-      this.hasLoaded = true;
-    } else {
-      await page.evaluate((options: any) => {
-        if (!(window as any).angular) {
-          window.location.href = options.url;
-          return true;
-        }
+    await page.evaluate((options: any) => {
+      if (!(window as any).angular) {
+        window.location.href = options.url;
+        return true;
+      }
 
-        const url = new URL(options.url);
-        const injector = (window as any).angular.element(document.body).injector();
-        const $locationService = injector.get('$location');
+      const url = new URL(options.url);
+      const injector = (window as any).angular.element(document.body).injector();
+      const $locationService = injector.get('$location');
 
-        // const link = document.createElement("a");
-        // link.appendChild(document.createTextNode("text"))
-        // link.href = ""
+      // const link = document.createElement("a");
+      // link.appendChild(document.createTextNode("text"))
+      // link.href = ""
 
-        $locationService.url(url.pathname + url.search);
+      $locationService.url(url.pathname + url.search);
 
-        return new Promise(resolve => {
-          injector.get('$rootScope').$digest();
-          setTimeout(resolve, 50);
-        });
-      }, options);
-    }
+      return new Promise(resolve => {
+        injector.get('$rootScope').$digest();
+        setTimeout(resolve, 50);
+      });
+    }, options);
 
     if (this.config.verboseLogging) {
       this.log.debug('Waiting for dashboard/panel to load', 'timeout', `${options.timeout}s`);

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -196,6 +196,8 @@ export class Browser {
 
       $locationService.url(url.pathname + url.search);
 
+      (window as any).panelsRendered = 0;
+
       return new Promise(resolve => {
         injector.get('$rootScope').$digest();
         setTimeout(resolve, 50);


### PR DESCRIPTION
Fixes #124

This is a very hacky POC to explore the biggest potential avenue for performance improvement, getting rid of full-page reloads between image renderings.

The first image takes the normal amount of time: 2-3 seconds 

After that, the image renderings take about 200 - 300ms (assuming the panel queries are very fast) 

This needs a lot more work to be production-ready. There could be big security issues with this approach that needs to be investigated. And more complex logic that validates that the rendered panel is for the same instance and org as the last render request, need a way to cache browser pages per org. 

Todo
* [ ] Address security concerns
* [ ] Cache pages per org & user
* [ ] Every 50x render (or some number) do a full page reload to avoid memory leaks causing issues
* [ ] Fix rendering different panel on same dashboard (should be easy) 
* [ ] Need not reuse for concurrent requests
* [ ] Needs updates to SoloPanelPage to support navigating between dashboards (needs cleanup), and panel on the same dashboard. 

