### PR TITLE
circleci: upgrade docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,8 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: 'Build and push Docker image'
           command: ./scripts/build_push_docker.sh


### PR DESCRIPTION
Attempting to apply this fix for the CircleCI build: https://support.circleci.com/hc/en-us/articles/360050934711

The Docker build is failing: https://app.circleci.com/pipelines/github/grafana/grafana-image-renderer/243/workflows/49ad3267-49ca-42f7-94b0-c91ed2ed05c8/jobs/732

with this error:

```
error An unexpected error occurred: "EPERM: operation not permitted, copyfile '/usr/local/share/.cache/yarn/v6/npm-core-util-is-1.0.2-b5fd54220aa2bc5ab57aab7140c940754503c1a7-integrity/node_modules/core-util-is/LICENSE' -> '/usr/src/app/node_modules/core-util-is/LICENSE'".
```