### PR TITLE
Chore: bump Node to LTS (14.16.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/grafana-image-renderer
   docker:
-    - image: circleci/node:12.13.1-stretch
+    - image: circleci/node:14.16.1-stretch
 
 commands:
   install-grabpl:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine AS base
+FROM node:14-alpine AS base
 
 ENV CHROME_BIN="/usr/bin/chromium-browser"
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim AS base
+FROM node:14-slim AS base
 
 ENV CHROME_BIN="google-chrome-unstable"
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -263,7 +263,7 @@ nodejs_heap_space_size_available_bytes{space="new_large_object"} 1047488 1579444
 
 # HELP nodejs_version_info Node.js version info.
 # TYPE nodejs_version_info gauge
-nodejs_version_info{version="v12.13.1",major="12",minor="13",patch="1"} 1
+nodejs_version_info{version="v14.16.1",major="14",minor="16",patch="1"} 1
 
 # HELP grafana_image_renderer_service_http_request_duration_seconds duration histogram of http responses labeled with: status_code
 # TYPE grafana_image_renderer_service_http_request_duration_seconds histogram

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.11.1",
-    "@types/node": "^10.0.9",
+    "@types/node": "^14.14.41",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",
     "pkg": "4.4.8",
@@ -64,9 +64,9 @@
   },
   "bin": "build/app.js",
   "engines": {
-    "node": ">=12 <13"
+    "node": ">=14 <15"
   },
   "volta": {
-    "node": "12.19.0"
+    "node": "14.16.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,10 +225,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.8.tgz#1d590429fe8187a02707720ecf38a6fe46ce294b"
   integrity sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
 
-"@types/node@^10.0.9", "@types/node@^10.1.0":
+"@types/node@^10.1.0":
   version "10.17.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+
+"@types/node@^14.14.41":
+  version "14.14.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
+  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Hi! :wave:

After bumping our own stuff to Node 14, I noticed that this image is still on Node 12.

I think I've changed all the necessary things – relying on the implicit `latest` tag in the Dockerfiles to get at least Node 14.16.1 – and the app starts up fine.