### PR TITLE
CSV: replace rename file with copy and unlink

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -294,9 +294,10 @@ export class Browser {
 
     let filePath = downloadFilePath;
     if (options.filePath) {
-      fs.renameSync(downloadFilePath, options.filePath);
-      filePath = options.filePath;
+      fs.copyFileSync(downloadFilePath, options.filePath);
+      fs.unlinkSync(downloadFilePath);
       fs.rmdirSync(path.dirname(downloadFilePath));
+      filePath = options.filePath;
     }
 
     return { filePath, fileName: path.basename(downloadFilePath) };


### PR DESCRIPTION
Rename can’t be used to rename across devices so this PR replaces `renameSync` with `copyFileSync` and `unlinkSync`.