### PR TITLE
HTTP Server: add version endpoint to get the current version

### DIFF
--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -61,6 +61,10 @@ export class HttpServer {
     this.app.get('/', (req: express.Request, res: express.Response) => {
       res.send('Grafana Image Renderer');
     });
+    this.app.get('/render/version', (req: express.Request, res: express.Response) => {
+      const pluginInfo = require('../../plugin.json');
+      res.send({ version: pluginInfo.info.version });
+    });
 
     this.app.get('/render', asyncMiddleware(this.render));
     this.app.get('/render/csv', asyncMiddleware(this.renderCSV));


### PR DESCRIPTION
Add an endpoint for the HTTP Server mode to know the current version of the plugin that is running.

*Note: I'd prefer to have the path `/version` for the endpoint instead of `/render/version` but it's harder to handle on the Grafana side as the config field for the `rendererUrl` contains the `/render` endpoint.*