### PR TITLE
Chore: Don't fail PR build if plugin signing fails fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
       - run:
           name: Create and sign plugin manifest
           command: |
+            set +e
             if [ << parameters.skip_chromium >> = true ]; then
               /tmp/grabpl build-plugin-manifest ./dist/<< parameters.override_output >>
             else


### PR DESCRIPTION
Follow-up of https://github.com/grafana/grafana-image-renderer/pull/216

The default bash used in CircleCi is `/bin/bash -eo pipefail` and `-e` means:
> Exit immediately if a pipeline (which may consist of a single simple command), a subshell command enclosed in parentheses, or one of the commands executed as part of a command list enclosed by braces exits with a non-zero status.

As explained here: https://circleci.com/docs/2.0/configuration-reference/#default-shell-options