### PR TITLE
Add --disable-gpu in the default Chromium args

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,9 +19,7 @@
   },
   "rendering": {
     "chromeBin": null,
-    "args": [
-      "--no-sandbox"
-    ],
+    "args": ["--no-sandbox", "--disable-gpu"],
     "ignoresHttpsErrors": false,
 
     "timezone": null,

--- a/dev.json
+++ b/dev.json
@@ -19,10 +19,7 @@
   },
   "rendering": {
     "chromeBin": null,
-    "args": [
-      "--no-sandbox",
-      "--disable-setuid-sandbox"
-    ],
+    "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"],
     "ignoresHttpsErrors": false,
 
     "timezone": null,

--- a/devenv/docker/ha/config.json
+++ b/devenv/docker/ha/config.json
@@ -10,6 +10,7 @@
   "rendering": {
     "timezone": null,
     "chromeBin": null,
+    "args": ["--no-sandbox", "--disable-gpu"],
     "ignoresHttpsErrors": false,
     "timingMetrics": true,
     "mode": "default",

--- a/docs/remote_rendering_using_docker.md
+++ b/docs/remote_rendering_using_docker.md
@@ -78,7 +78,7 @@ RENDERING_DUMPIO=true
 
 **Start browser with additional arguments:**
 
-Additional arguments to pass to the headless browser instance. Default is `--no-sandbox`. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/). Multiple arguments is separated with comma-character.
+Additional arguments to pass to the headless browser instance. Defaults are `--no-sandbox,--disable-gpu`. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/) and the list of flags used as defaults by Puppeteer can be found [there](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts#L172). Multiple arguments is separated with comma-character. 
 
 ```bash
 RENDERING_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-accelerated-2d-canvas,--disable-gpu,--window-size=1280x758

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -15,6 +15,12 @@ export function createBrowser(config: RenderingConfig, log: Logger): Browser {
     return new ReusableBrowser(config, log);
   }
 
+  if (!config.args.includes['--disable-gpu']) {
+    log.warn(
+      'using default mode without the --disable-gpu flag is not recommended as it can cause Puppeteer newPage function to freeze, leaving browsers open'
+    );
+  }
+
   return new Browser(config, log);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,7 @@ export interface PluginConfig {
 
 const defaultRenderingConfig: RenderingConfig = {
   chromeBin: undefined,
-  args: ['--no-sandbox'],
+  args: ['--no-sandbox', '--disable-gpu'],
   ignoresHttpsErrors: false,
   timezone: undefined,
   acceptLanguage: undefined,


### PR DESCRIPTION
While doing some load testing of the application with the `default` rendering mode, I noticed high CPU and memory slowy going to the roof after the tests were finished. I narrowed down the issue to the `newPage` function that was (for some requests) hanging forever, preventing the browser to be closed and causing these issues. 

It seems like adding the `--disable-gpu` flag to the Chromium args fixed the issue.

Should fix https://github.com/grafana/grafana-image-renderer/issues/229