### PR TITLE
Docker: revert changes on the working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,11 @@ ARG GF_UID="472"
 ARG GF_GID="472"
 ENV GF_PATHS_HOME="/usr/src/app"
 
+ WORKDIR $GF_PATHS_HOME
+
 RUN addgroup -S -g $GF_GID grafana && \
     adduser -S -u $GF_UID -G grafana grafana && \
+    mkdir -p "$GF_PATHS_HOME" && \
     chown -R grafana:grafana "$GF_PATHS_HOME"
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,10 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 
 ARG GF_UID="472"
 ARG GF_GID="472"
-ENV GF_PATHS_HOME="/usr/share/grafana"
-
-WORKDIR $GF_PATHS_HOME
+ENV GF_PATHS_HOME="/usr/src/app"
 
 RUN addgroup -S -g $GF_GID grafana && \
     adduser -S -u $GF_UID -G grafana grafana && \
-    mkdir -p "$GF_PATHS_HOME" && \
     chown -R grafana:grafana "$GF_PATHS_HOME"
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ARG GF_UID="472"
 ARG GF_GID="472"
 ENV GF_PATHS_HOME="/usr/src/app"
 
- WORKDIR $GF_PATHS_HOME
+WORKDIR $GF_PATHS_HOME
 
 RUN addgroup -S -g $GF_GID grafana && \
     adduser -S -u $GF_UID -G grafana grafana && \


### PR DESCRIPTION
Use the same working directory as before to not break existing Docker set-ups.

I'm no Docker expert so if there is a benefit to use `/usr/share/grafana` instead of `/usr/src/app`, we can keep it but if there isn't, then, it's best to not introduce a breaking change for Docker users. 