### PR TITLE
Set the maximum device scale factor to 4 as default

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,7 +29,7 @@
     "deviceScaleFactor": 1,
     "maxWidth": 3080,
     "maxHeight": 3000,
-    "maxDeviceScaleFactor": 3,
+    "maxDeviceScaleFactor": 4,
 
     "mode": "default",
     "clustering": {

--- a/devenv/docker/custom-config/config.json
+++ b/devenv/docker/custom-config/config.json
@@ -31,7 +31,7 @@
     "deviceScaleFactor": 1,
     "maxWidth": 3080,
     "maxHeight": 3000,
-    "maxDeviceScaleFactor": 3,
+    "maxDeviceScaleFactor": 4,
 
     "mode": "clustered",
     "clustering": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,7 @@ const defaultRenderingConfig: RenderingConfig = {
   deviceScaleFactor: 1,
   maxWidth: 3000,
   maxHeight: 3000,
-  maxDeviceScaleFactor: 3,
+  maxDeviceScaleFactor: 4,
   mode: 'default',
   clustering: {
     mode: 'browser',


### PR DESCRIPTION
In the reporting configuration, we suggest to use `4` in the `image_scale_factor` field for printed materials. With the current defaults, it would be ignored and set to `1` as the default `maxDeviceScaleFactor` is `3`. This PR fixes that.