### PR TITLE
Instrumentation: Add gauge of total number of requests in flight

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.21",
     "minimist": "^1.2.0",
     "morgan": "^1.9.0",
+    "on-finished": "^2.3.0",
     "prom-client": "^11.5.3",
     "puppeteer": "^10.0.0",
     "puppeteer-cluster": "^0.22.0",

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -8,7 +8,7 @@ import * as promClient from 'prom-client';
 import { Logger } from '../logger';
 import { Browser, createBrowser } from '../browser';
 import { ServiceConfig } from '../config';
-import { metricsMiddleware } from './metrics_middleware';
+import { setupHttpServerMetrics } from './metrics_middleware';
 import { RenderOptions, RenderCSVOptions, HTTPHeaders, Metrics } from '../browser/browser';
 
 export interface RenderRequest {
@@ -58,7 +58,10 @@ export class HttpServer {
         stream: this.log.errorWriter,
       })
     );
-    this.app.use(metricsMiddleware(this.config.service.metrics, this.log));
+
+    if (this.config.service.metrics.enabled) {
+      setupHttpServerMetrics(this.app, this.config.service.metrics, this.log);
+    }
     this.app.get('/', (req: express.Request, res: express.Response) => {
       res.send('Grafana Image Renderer');
     });

--- a/src/service/metrics_middleware.ts
+++ b/src/service/metrics_middleware.ts
@@ -59,7 +59,6 @@ const requestsInFlightMiddleware = (httpRequestsInFlight: promClient.Gauge, excl
     httpRequestsInFlight.inc();
     onFinished(res, () => {
       httpRequestsInFlight.dec();
-      next();
     });
 
     next();


### PR DESCRIPTION
Add gauge of total number of requests in flight (only for `/render/*` routes). 

Closes https://github.com/grafana/grafana-image-renderer/issues/234