### PR TITLE
Configuration: add timeout setting for clustered mode

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,7 +34,8 @@
     "mode": "default",
     "clustering": {
       "mode": "browser",
-      "maxConcurrency": 5
+      "maxConcurrency": 5,
+      "timeout": 30
     },
 
     "verboseLogging": false,

--- a/dev.json
+++ b/dev.json
@@ -34,7 +34,8 @@
     "mode": "default",
     "clustering": {
       "mode": "browser",
-      "maxConcurrency": 5
+      "maxConcurrency": 5,
+      "timeout": 30
     },
 
     "verboseLogging": true,

--- a/devenv/docker/custom-config/config.json
+++ b/devenv/docker/custom-config/config.json
@@ -36,7 +36,8 @@
     "mode": "clustered",
     "clustering": {
       "mode": "context",
-      "maxConcurrency": 5
+      "maxConcurrency": 5,
+      "timeout": 30
     },
 
     "verboseLogging": false,

--- a/devenv/docker/ha/config.json
+++ b/devenv/docker/ha/config.json
@@ -15,7 +15,8 @@
     "mode": "default",
     "clustering": {
       "mode": "browser",
-      "maxConcurrency": 5
+      "maxConcurrency": 5,
+      "timeout": 30
     },
     "timingMetrics": true
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -124,6 +124,10 @@ function populateServiceConfigFromEnv(config: ServiceConfig, env: NodeJS.Process
     config.rendering.clustering.maxConcurrency = parseInt(env['RENDERING_CLUSTERING_MAX_CONCURRENCY'] as string, 10);
   }
 
+  if (env['RENDERING_CLUSTERING_TIMEOUT']) {
+    config.rendering.clustering.timeout = parseInt(env['RENDERING_CLUSTERING_TIMEOUT'] as string, 10);
+  }
+
   if (env['RENDERING_VERBOSE_LOGGING']) {
     config.rendering.verboseLogging = env['RENDERING_VERBOSE_LOGGING'] === 'true';
   }

--- a/src/browser/clustered.ts
+++ b/src/browser/clustered.ts
@@ -36,7 +36,7 @@ export class ClusteredBrowser extends Browser {
     this.cluster = await Cluster.launch({
       concurrency: this.concurrency,
       maxConcurrency: this.clusteringConfig.maxConcurrency,
-      timeout: this.clusteringConfig.timeout,
+      timeout: this.clusteringConfig.timeout * 1000,
       puppeteerOptions: launcherOptions,
     });
     await this.cluster.task(async ({ page, data }) => {

--- a/src/browser/clustered.ts
+++ b/src/browser/clustered.ts
@@ -36,6 +36,7 @@ export class ClusteredBrowser extends Browser {
     this.cluster = await Cluster.launch({
       concurrency: this.concurrency,
       maxConcurrency: this.clusteringConfig.maxConcurrency,
+      timeout: this.clusteringConfig.timeout,
       puppeteerOptions: launcherOptions,
     });
     await this.cluster.task(async ({ page, data }) => {

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -6,7 +6,15 @@ import { ReusableBrowser } from './reusable';
 
 export function createBrowser(config: RenderingConfig, log: Logger, metrics: Metrics): Browser {
   if (config.mode === 'clustered') {
-    log.info('using clustered browser', 'mode', config.clustering.mode, 'maxConcurrency', config.clustering.maxConcurrency, 'timeout',config.clustering.timeout);
+    log.info(
+      'using clustered browser',
+      'mode',
+      config.clustering.mode,
+      'maxConcurrency',
+      config.clustering.maxConcurrency,
+      'timeout',
+      config.clustering.timeout
+    );
     return new ClusteredBrowser(config, log, metrics);
   }
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -6,7 +6,7 @@ import { ReusableBrowser } from './reusable';
 
 export function createBrowser(config: RenderingConfig, log: Logger, metrics: Metrics): Browser {
   if (config.mode === 'clustered') {
-    log.info('using clustered browser', 'mode', config.clustering.mode, 'maxConcurrency', config.clustering.maxConcurrency);
+    log.info('using clustered browser', 'mode', config.clustering.mode, 'maxConcurrency',config.clustering.maxConcurrency, 'timeout',config.clustering.timeout);
     return new ClusteredBrowser(config, log, metrics);
   }
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -6,7 +6,7 @@ import { ReusableBrowser } from './reusable';
 
 export function createBrowser(config: RenderingConfig, log: Logger, metrics: Metrics): Browser {
   if (config.mode === 'clustered') {
-    log.info('using clustered browser', 'mode', config.clustering.mode, 'maxConcurrency',config.clustering.maxConcurrency, 'timeout',config.clustering.timeout);
+    log.info('using clustered browser', 'mode', config.clustering.mode, 'maxConcurrency', config.clustering.maxConcurrency, 'timeout',config.clustering.timeout);
     return new ClusteredBrowser(config, log, metrics);
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 export interface ClusteringConfig {
   mode: string;
   maxConcurrency: number;
+  timeout: number;
 }
 
 export interface RenderingConfig {
@@ -77,6 +78,7 @@ const defaultRenderingConfig: RenderingConfig = {
   clustering: {
     mode: 'browser',
     maxConcurrency: 5,
+    timeout: 30,
   },
   verboseLogging: false,
   dumpio: false,

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -247,6 +247,10 @@ const populateConfigFromEnv = (config: PluginConfig) => {
     config.rendering.clustering.maxConcurrency = parseInt(env['GF_PLUGIN_RENDERING_CLUSTERING_MAX_CONCURRENCY'] as string, 10);
   }
 
+  if (env['GF_PLUGIN_RENDERING_CLUSTERING_TIMEOUT']) {
+    config.rendering.clustering.timeout = parseInt(env['GF_PLUGIN_RENDERING_CLUSTERING_TIMEOUT'] as string, 10);
+  }
+
   if (env['GF_PLUGIN_RENDERING_VERBOSE_LOGGING']) {
     config.rendering.verboseLogging = env['GF_PLUGIN_RENDERING_VERBOSE_LOGGING'] === 'true';
   }


### PR DESCRIPTION
Add timeout setting that overrides puppeteer-cluster timeout. 

Fixes https://github.com/grafana/grafana-image-renderer/issues/279