### PR TITLE
Types: improve options types

### DIFF
--- a/src/browser/clustered.ts
+++ b/src/browser/clustered.ts
@@ -1,5 +1,6 @@
 import { Cluster } from 'puppeteer-cluster';
-import { Browser, RenderResponse, RenderOptions, RenderCSVOptions, RenderCSVResponse, Metrics } from './browser';
+import { ImageRenderOptions, RenderOptions } from '../types';
+import { Browser, RenderResponse, RenderCSVResponse, Metrics } from './browser';
 import { Logger } from '../logger';
 import { RenderingConfig, ClusteringConfig } from '../config';
 
@@ -9,7 +10,7 @@ enum RenderType {
 }
 
 interface ClusterOptions {
-  options: RenderOptions | RenderCSVOptions;
+  options: RenderOptions | ImageRenderOptions;
   renderType: RenderType;
 }
 
@@ -52,7 +53,7 @@ export class ClusteredBrowser extends Browser {
             return await this.exportCSV(page, data.options);
           case RenderType.PNG:
           default:
-            return await this.takeScreenshot(page, data.options);
+            return await this.takeScreenshot(page, data.options as ImageRenderOptions);
         }
       } finally {
         this.removePageListeners(page);
@@ -60,12 +61,12 @@ export class ClusteredBrowser extends Browser {
     });
   }
 
-  async render(options: RenderOptions): Promise<RenderResponse> {
+  async render(options: ImageRenderOptions): Promise<RenderResponse> {
     this.validateImageOptions(options);
     return this.cluster.execute({ options, renderType: RenderType.PNG });
   }
 
-  async renderCSV(options: RenderCSVOptions): Promise<RenderCSVResponse> {
+  async renderCSV(options: RenderOptions): Promise<RenderCSVResponse> {
     this.validateRenderOptions(options);
     return this.cluster.execute({ options, renderType: RenderType.CSV });
   }

--- a/src/browser/reusable.ts
+++ b/src/browser/reusable.ts
@@ -1,5 +1,6 @@
 import * as puppeteer from 'puppeteer';
-import { Browser, RenderResponse, RenderOptions, RenderCSVResponse, RenderCSVOptions, Metrics } from './browser';
+import { ImageRenderOptions, RenderOptions } from '../types';
+import { Browser, RenderResponse, RenderCSVResponse, Metrics } from './browser';
 import { Logger } from '../logger';
 import { RenderingConfig } from '../config';
 
@@ -15,7 +16,7 @@ export class ReusableBrowser extends Browser {
     this.browser = await puppeteer.launch(launcherOptions);
   }
 
-  async render(options: RenderOptions): Promise<RenderResponse> {
+  async render(options: ImageRenderOptions): Promise<RenderResponse> {
     let context: puppeteer.BrowserContext | undefined;
     let page: puppeteer.Page | undefined;
 
@@ -45,7 +46,7 @@ export class ReusableBrowser extends Browser {
     }
   }
 
-  async renderCSV(options: RenderCSVOptions): Promise<RenderCSVResponse> {
+  async renderCSV(options: RenderOptions): Promise<RenderCSVResponse> {
     let context: puppeteer.BrowserContext | undefined;
     let page: puppeteer.Page | undefined;
 

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -5,7 +5,7 @@ import { GrpcPlugin } from '../../node-plugin';
 import { Logger } from '../../logger';
 import { PluginConfig } from '../../config';
 import { createBrowser, Browser } from '../../browser';
-import { RenderOptions, RenderCSVOptions, HTTPHeaders } from '../../browser/browser';
+import { HTTPHeaders, ImageRenderOptions, RenderOptions } from '../../types';
 import {
   RenderRequest,
   RenderResponse,
@@ -100,7 +100,7 @@ class PluginGRPCServer {
       }
     }
 
-    const options: RenderOptions = {
+    const options: ImageRenderOptions = {
       url: req.url,
       width: req.width,
       height: req.height,
@@ -141,7 +141,7 @@ class PluginGRPCServer {
       }
     }
 
-    const options: RenderCSVOptions = {
+    const options: RenderOptions = {
       url: req.url,
       filePath: req.filePath,
       timeout: req.timeout,

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -9,30 +9,7 @@ import { Logger } from '../logger';
 import { Browser, createBrowser } from '../browser';
 import { ServiceConfig } from '../config';
 import { setupHttpServerMetrics } from './metrics_middleware';
-import { RenderOptions, RenderCSVOptions, HTTPHeaders, Metrics } from '../browser/browser';
-
-export interface RenderRequest {
-  url: string;
-  width: number;
-  height: number;
-  deviceScaleFactor: number;
-  filePath: string;
-  renderKey: string;
-  domain: string;
-  timeout: number;
-  timezone: string;
-  encoding: string;
-}
-
-export interface RenderCSVRequest {
-  url: string;
-  filePath: string;
-  renderKey: string;
-  domain: string;
-  timeout: number;
-  timezone: string;
-  encoding: string;
-}
+import { HTTPHeaders, ImageRenderOptions, RenderOptions } from '../types';
 
 export class HttpServer {
   app: express.Express;
@@ -123,7 +100,7 @@ export class HttpServer {
     await this.browser.start();
   }
 
-  render = async (req: express.Request<any, any, any, RenderRequest, any>, res: express.Response, next: express.NextFunction) => {
+  render = async (req: express.Request<any, any, any, ImageRenderOptions, any>, res: express.Response, next: express.NextFunction) => {
     if (!req.query.url) {
       throw boom.badRequest('Missing url parameter');
     }
@@ -134,7 +111,7 @@ export class HttpServer {
       headers['Accept-Language'] = (req.headers['Accept-Language'] as string[]).join(';');
     }
 
-    const options: RenderOptions = {
+    const options: ImageRenderOptions = {
       url: req.query.url,
       width: req.query.width,
       height: req.query.height,
@@ -169,7 +146,7 @@ export class HttpServer {
     });
   };
 
-  renderCSV = async (req: express.Request<any, any, any, RenderCSVRequest, any>, res: express.Response, next: express.NextFunction) => {
+  renderCSV = async (req: express.Request<any, any, any, RenderOptions, any>, res: express.Response, next: express.NextFunction) => {
     if (!req.query.url) {
       throw boom.badRequest('Missing url parameter');
     }
@@ -180,7 +157,7 @@ export class HttpServer {
       headers['Accept-Language'] = (req.headers['Accept-Language'] as string[]).join(';');
     }
 
-    const options: RenderCSVOptions = {
+    const options: RenderOptions = {
       url: req.query.url,
       filePath: req.query.filePath,
       timeout: req.query.timeout,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,22 @@
+export interface HTTPHeaders {
+  'Accept-Language'?: string;
+  [header: string]: string | undefined;
+}
+
+// Common options for CSV and Images
+export interface RenderOptions {
+  url: string;
+  filePath: string;
+  timeout: number; // seconds
+  renderKey: string;
+  domain: string;
+  timezone?: string;
+  encoding?: string;
+  headers?: HTTPHeaders;
+}
+
+export interface ImageRenderOptions extends RenderOptions {
+  width: string | number;
+  height: string | number;
+  deviceScaleFactor?: string | number;
+}


### PR DESCRIPTION
There are currently two types `RenderOptions` and `RenderCSVOptions` however, CSV is just a subset of the other types.  In addition, the HTTP server has an identical type but it is called `RenderRequest`  -- grpc plugin has a similar type -- but headers is string[] rather than string so :man_shrugging: 

This PR:
1. adds a types.ts file to root and puts RenderOptions and ImageRenderOptions there
2. avoids using `any` in function calls
3. use the same options type for browser and server

This has no behavior changes

