### PR TITLE
Add `linux-musl` build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ workflows:
           name: package-<< matrix.arch >>
           matrix:
             parameters:
-              arch: [linux-x64-glibc, darwin-x64-unknown, win32-x64-unknown]
+              arch: [linux-x64-glibc, linux-x64-musl, darwin-x64-unknown, win32-x64-unknown]
       - package:
           filters: *filter-only-master
           requires:
@@ -224,6 +224,14 @@ workflows:
           arch: linux-x64-glibc
           skip_chromium: true
           override_output: plugin-linux-x64-glibc-no-chromium
+      - package:
+          filters: *filter-only-master
+          requires:
+            - build
+          name: package-linux-x64-musl-no-chromium
+          arch: linux-x64-musl
+          skip_chromium: true
+          override_output: plugin-linux-x64-musl-no-chromium
       - publish-docker-master:
           requires:
             - build
@@ -233,9 +241,11 @@ workflows:
           requires:
             - build
             - package-linux-x64-glibc
+            - package-linux-x64-musl
             - package-darwin-x64-unknown
             - package-win32-x64-unknown
             - package-linux-x64-glibc-no-chromium
+            - package-linux-x64-musl-no-chromium
           filters: *filter-only-master
       - publish-github-release:
           requires:
@@ -260,7 +270,7 @@ workflows:
           name: package-<< matrix.arch >>
           matrix:
             parameters:
-              arch: [linux-x64-glibc, darwin-x64-unknown, win32-x64-unknown]
+              arch: [linux-x64-glibc, linux-x64-musl, darwin-x64-unknown, win32-x64-unknown]
               skip_signing_errors: [true]
 
       - package:
@@ -271,6 +281,16 @@ workflows:
           arch: linux-x64-glibc
           skip_chromium: true
           override_output: plugin-linux-x64-glibc-no-chromium
+          skip_signing_errors: true
+
+      - package:
+          filters: *filter-not-release-or-master
+          requires:
+            - build
+          name: package-linux-x64-musl-no-chromium
+          arch: linux-x64-musl
+          skip_chromium: true
+          override_output: plugin-linux-x64-musl-no-chromium
           skip_signing_errors: true
 
 executors:

--- a/scripts/download_sharp.js
+++ b/scripts/download_sharp.js
@@ -4,10 +4,15 @@ const fs = require('fs')
 const archArg = process.argv[2];
 
 // https://sharp.pixelplumbing.com/install#cross-platform
-const [
+let [
     platform, // linux, darwin, win32
-    arch // x64, ia32, arm, arm64
+    arch, // x64, ia32, arm, arm64
+    libc
 ] = archArg.split('-');
+
+if (platform === 'linux' &&  libc === 'musl') {
+    platform = 'linuxmusl'
+}
 
 const packageJson = JSON.parse(fs.readFileSync('./package.json'))
 


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-image-renderer/issues/323

CI-build artifact: 
https://github.com/grafana/grafana-image-renderer/blob/linux-musl-build-test-artifact/testartifacts/plugin-linux-x64-musl-no-chromium.zip?raw=true


To test:
1. modify `<project_dir>/grafana/packaging/docker/custom/Dockerfile`: replace the value of `pluginUrl` with the CI-built `linux-musl` version: https://github.com/grafana/grafana-image-renderer/blob/linux-musl-build-test-artifact/testartifacts/plugin-linux-x64-musl-no-chromium.zip?raw=true
2. `docker build   --build-arg "GRAFANA_VERSION=latest"   --build-arg "GF_INSTALL_IMAGE_RENDERER_PLUGIN=true"   -t grafana-custom -f Dockerfile .`
3. `docker run -d -p 3000:3000 --name=grafana-custom grafana-custom`