### PR TITLE
Fix arm64 build for m1 with docker-desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Grafana backend plugin that handles rendering panels and dashboards to PNGs us
 
 ### Supported operating systems
 
-- Linux (x64)
+- Linux (x64, arm64)
 - Windows (x64)
 - Mac OS X (x64)
 

--- a/scripts/pkg.js
+++ b/scripts/pkg.js
@@ -17,8 +17,7 @@ const platformTransform = {
 const archTransform = {
   ia32: 'x84',
   arm: 'armv6',
-  // I only assume this is correct
-  arm64: 'armv6',
+  arm64: 'arm64',
 };
 
 platform = platformTransform[platform] || platform;


### PR DESCRIPTION
I needed to build a Grafana image that had to run on an M1 with docker-desktop. Therefore, I tried to build using the command suggested in https://github.com/grafana/grafana-image-renderer/issues/65#issuecomment-562082850, but it failed during packaging `Unknown token 'armv6' in 'node14-linux-armv6'`.
I looked into the `package_target.sh` and saw that the `arm64` architecture was mapped to `armv6` which seems to be the issue. Changing this to `arm64` allowed me to build for `linux-arm64-glibc`.

Then I build a Grafana docker image on my m1 mac using docker-desktop and the plugin seemed to work.
![image](https://user-images.githubusercontent.com/9028609/156332625-ff1882bd-bdd4-41f0-b3c6-f4739638a557.png)

Note:
- I only tested this on my m1 mac with docker-desktop
- I only tested the version with a bundled chromium
- I don't know if this change breaks other setups, since I don't have access to other systems.
