### PR TITLE
Upgrade dependencies when installing curl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - run:
           name: Run Veracode scan
           command: |
-            apk add curl
+            apk add --update-cache --upgrade curl
             # Increase heap size or the scanner will die.
             export _JAVA_OPTIONS=-Xmx4g
             mkdir -p ci/jobs/security_scan


### PR DESCRIPTION
`Workflow: build-branches-and-prs` always fails. Even after adding `curl` with `apk`, the old `libcurl` is still loaded, so `curl` is failing and should be upgraded when installing with `apk`.

```plan
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
(1/1) Installing curl (7.83.1-r1)
  0%                                             % ############################################Executing busybox-1.31.1-r9.trigger
OK: 346 MiB in 70 packages
Error relocating /usr/bin/curl: curl_easy_nextheader: symbol not found
Error relocating /usr/bin/curl: curl_easy_header: symbol not found

Exited with code exit status 127
CircleCI received exit code 127
```

ref curl/curl#4357