### PR TITLE
CI: fix scan Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,4 +276,4 @@ workflows:
 executors:
   scan_exec:
     docker:
-    - image: srclosson/grafana-plugin-ci-alpine:latest
+    - image: grafana/grafana-plugin-ci-alpine:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,4 +276,4 @@ workflows:
 executors:
   scan_exec:
     docker:
-    - image: grafana/grafana-plugin-ci-alpine:latest
+    - image: grafana/grafana-plugin-ci:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,4 +276,4 @@ workflows:
 executors:
   scan_exec:
     docker:
-    - image: grafana/grafana-plugin-ci:latest
+    - image: grafana/grafana-plugin-ci:1.4.1-alpine


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana-image-renderer/pull/352 

I think this is better to use the `grafana` Docker image instead of an individual one that could be used to test things or be outdated. 