### PR TITLE
Release grafana-image-renderer v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.0 (2022-07-07)
+
+- Added File Sanitization API with [DOMPurify](https://github.com/cure53/DOMPurify) as the backend. [#349](https://github.com/grafana/grafana-image-renderer/pull/349), [ArturWierzbicki](https://github.com/ArturWierzbicki)
+
 ## 3.4.2 (2022-03-23)
 
 - Security: upgrade dependencies [#337](https://github.com/grafana/grafana-image-renderer/pull/337), [AgnesToulet](https://github.com/AgnesToulet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.5.0 (2022-07-18)
 
 - Added File Sanitization API with [DOMPurify](https://github.com/cure53/DOMPurify) as the backend. [#349](https://github.com/grafana/grafana-image-renderer/pull/349), [ArturWierzbicki](https://github.com/ArturWierzbicki)
-- Security: upgrade dependencies [#356](https://github.com/grafana/grafana-image-renderer/pull/356), [AgnesToulet](https://github.com/AgnesToulet)
+- Security: upgrade dependencies [#356](https://github.com/grafana/grafana-image-renderer/pull/356), [#348](https://github.com/grafana/grafana-image-renderer/pull/348), [#347](https://github.com/grafana/grafana-image-renderer/pull/347),  [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.4.2 (2022-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.0 (2022-07-07)
+## 3.5.0 (2022-07-18)
 
 - Added File Sanitization API with [DOMPurify](https://github.com/cure53/DOMPurify) as the backend. [#349](https://github.com/grafana/grafana-image-renderer/pull/349), [ArturWierzbicki](https://github.com/ArturWierzbicki)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.5.0 (2022-07-18)
 
 - Added File Sanitization API with [DOMPurify](https://github.com/cure53/DOMPurify) as the backend. [#349](https://github.com/grafana/grafana-image-renderer/pull/349), [ArturWierzbicki](https://github.com/ArturWierzbicki)
+- Security: upgrade dependencies [#356](https://github.com/grafana/grafana-image-renderer/pull/356), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.4.2 (2022-03-23)
 

--- a/plugin.json
+++ b/plugin.json
@@ -20,8 +20,8 @@
       {"name": "Project site", "url": "https://github.com/grafana/grafana-image-renderer"},
       {"name": "Apache License", "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"}
     ],
-    "version": "3.4.2",
-    "updated": "2022-03-23"
+    "version": "3.5.0",
+    "updated": "2022-07-07"
   },
   "dependencies": {
     "grafanaDependency": ">=7.0.0"

--- a/plugin.json
+++ b/plugin.json
@@ -21,7 +21,7 @@
       {"name": "Apache License", "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"}
     ],
     "version": "3.5.0",
-    "updated": "2022-07-07"
+    "updated": "2022-07-18"
   },
   "dependencies": {
     "grafanaDependency": ">=7.0.0"


### PR DESCRIPTION
`prepare` step from https://github.com/grafana/grafana-image-renderer/blob/master/docs/release_new_version.md#prepare