### PR TITLE
Bump jpeg-js from 0.4.2 to 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "tsc-watch": "^4.2.3",
     "typescript": "^4.3.2"
   },
+  "resolutions": {
+    "jpeg-js": "^0.4.4"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged && npm run precommit"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,10 +2748,10 @@ jimp@0.16.1:
     "@jimp/types" "^0.16.1"
     regenerator-runtime "^0.13.3"
 
-jpeg-js@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
-  integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
+jpeg-js@0.4.2, jpeg-js@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Bump jpeg-js from 0.4.2 to 0.4.4 to fix following vulnerability: CVE-2022-25851