### PR TITLE
Fix invalid Content-Disposition

### DIFF
--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -234,7 +234,7 @@ export class HttpServer {
     const result = await this.browser.renderCSV(options);
 
     if (result.fileName) {
-      res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
+      res.setHeader('Content-Disposition', `attachment; filename="${encodeURI(result.fileName)}"`);
     }
     res.sendFile(result.filePath, (err) => {
       if (err) {

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -234,7 +234,10 @@ export class HttpServer {
     const result = await this.browser.renderCSV(options);
 
     if (result.fileName) {
-      res.setHeader('Content-Disposition', `attachment; filename="${encodeURI(result.fileName)}"`);
+      if (!/^[\u0000-\u007f]*$/.test(result.fileName)) {
+        result.fileName = '';
+      }
+      res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
     }
     res.sendFile(result.filePath, (err) => {
       if (err) {

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -14,6 +14,7 @@ import { Sanitizer } from '../sanitizer/Sanitizer';
 import * as bodyParser from 'body-parser';
 import * as multer from 'multer';
 import { isSanitizeRequest } from '../sanitizer/types';
+import * as contentDisposition from 'content-disposition';
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -234,10 +235,7 @@ export class HttpServer {
     const result = await this.browser.renderCSV(options);
 
     if (result.fileName) {
-      if (!/^[\u0000-\u007f]*$/.test(result.fileName)) {
-        result.fileName = '';
-      }
-      res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
+      res.setHeader('Content-Disposition', contentDisposition(result.fileName));
     }
     res.sendFile(result.filePath, (err) => {
       if (err) {


### PR DESCRIPTION
It uses `content-disposition` library to accept non-ascii characters in Content-Disposition header. Right now its failing when it's happening and we aren't creating the csv.

Related issue: https://github.com/grafana/grafana-enterprise/issues/3576