### PR TITLE
Update waiting condition for full page screenshots

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -361,7 +361,6 @@ export class Browser {
           height: scrollResult.scrollHeight,
         });
       }
-
       return page.screenshot({ path: options.filePath, fullPage: options.fullPageImage, captureBeyondViewport: options.fullPageImage || false });
     }, 'screenshot');
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -327,7 +327,17 @@ export class Browser {
 
         return page.waitForFunction(
           (isFullPage) => {
+            /**
+             * panelsRendered value is updated every time that a panel renders. It could happen multiple times in a same panel because scrolling. For full page screenshots
+             * we can reach panelsRendered >= panelCount condition even if we have panels that are still loading data and their panelsRenderer value is 0, generating
+             * a screenshot with loading panels. It's why the condition for full pages is different from a single panel.
+             */
             if (isFullPage) {
+              /**
+               * data-panelId is the total number of the panels in the dashboard. Rows included.
+               * panel-content only exists in non-row panels when the data is loaded.
+               * dashboard-row exists only in rows.
+               */
               const panelCount = document.querySelectorAll('[data-panelId]').length;
               const totalPanelsRendered = document.querySelectorAll('.panel-content').length + document.querySelectorAll('.dashboard-row').length;
               return totalPanelsRendered === panelCount;

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -78,7 +78,11 @@ export class HttpServer {
         this.log.error('Request failed', 'url', req.url, 'error', err);
       }
 
-      return res.status(err.output.statusCode).json(err.output.payload);
+      if (err.output) {
+        return res.status(err.output.statusCode).json(err.output.payload);
+      }
+
+      return res.status(500).json(err);
     });
 
     if (this.config.service.host) {


### PR DESCRIPTION
The condition that we are using for individual panels isn't working for full page screenshots.

`panelsRendered` value is increased every time a panel is rendered. But a panel could be renderer several times when scrolling. For example, when a panel is partially visible increases `panelsRendered`, and when scroll, it increases this value again. 

So `(window as any).panelsRendered >= panelCount` could be success even if we have any panel loading data. If we have a slow query, the result could be a screenshot with a loading panel, when we are expecting to see data.

The condition for full pages is the following:
* Count `[data-panelId]` as total panels of the dashboard (rendered or not). It includes rows and panels.
* `.dashboard-row` returns the number of rows.
* `.panel-content` returns the value of RENDERED panels excluding rows (rows don't have this class).

So the condition is going to wait to all panels to render OR reach the timeout.