### PR TITLE
Update _client with _client() to avoid to fail when creating a CSV

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -432,7 +432,7 @@ export class Browser {
       }
     });
 
-    await page._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: downloadPath });
+    await page._client().send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: downloadPath });
 
     if (this.config.verboseLogging) {
       this.log.debug('Navigating and waiting for all network requests to finish', 'url', options.url);


### PR DESCRIPTION
It changes `_client` with `_client()` to make CSV works with last puppeteer update.

Fixes: https://github.com/grafana/grafana-image-renderer/issues