### PR TITLE
Updated the clone url to point to the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker-compose up
 
 The following example describes how to build and run the remote HTTP rendering service as a standalone Node.js application and configure Grafana appropriately.
 
-1. Clone the [Grafana image renderer plugin](https://grafana.com/grafana/plugins/grafana-image-renderer) Git repository.
+1. Clone the [Grafana image renderer plugin](https://github.com/grafana/grafana-image-renderer/) Git repository.
 1. Install dependencies and build:
 
    ```bash


### PR DESCRIPTION
Changed https://grafana.com/grafana/plugins/grafana-image-renderer into https://github.com/grafana/grafana-image-renderer/ where the git clone is referenced