### PR TITLE
Log errors related to JSHandle@object as debug

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -522,8 +522,8 @@ export class Browser {
     }
 
     const loc = msg.location();
-    if (msgType === 'error') {
-      this.log.error('Browser console error', 'msg', msg.text(), 'url', loc.url, 'line', loc.lineNumber, 'column', loc.columnNumber);
+    if (msgType === 'error' && msg.text() !== 'JSHandle@object') {
+        this.log.error('Browser console error', 'msg', msg.text(), 'url', loc.url, 'line', loc.lineNumber, 'column', loc.columnNumber);
       return;
     }
 


### PR DESCRIPTION
Errors related to `JSHandle@object` are showing like errors when in most of the cases is because it cannot load a `js` that doesn't affect to the screenshot. I didn't see this error in other other cases.

The result when image-renderer is used as plugin is that it's showing a lot of annoying messages on logs because they are errors, but down the log level to debug removes a lot of noisy.