### PR TITLE
Handle server crash when req.failure() is null

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -536,7 +536,7 @@ export class Browser {
   };
 
   logRequestFailed = (req: any) => {
-    this.log.error('Browser request failed', 'url', req.url(), 'method', req.method(), 'failure', req.failure().errorText);
+    this.log.error('Browser request failed', 'url', req.url(), 'method', req.method(), 'failure', req.failure()?.errorText);
   };
 
   logRequestFinished = (req: any) => {


### PR DESCRIPTION
In some cases the browser request error is null and logging it directly as `req.failure().errorText` will cause the plugin to crash.

Fix is just to handle if `req.failure()` is undefined or not