### PR TITLE
Stop doing security scans on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,9 +250,6 @@ workflows:
     jobs:
       - build:
           filters: *filter-not-release-or-master
-      - security_scan:
-          requires:
-            - build
       - package:
           filters: *filter-not-release-or-master
           requires:
@@ -262,7 +259,6 @@ workflows:
             parameters:
               arch: [linux-x64-glibc, darwin-x64-unknown, win32-x64-unknown]
               skip_signing_errors: [true]
-
       - package:
           filters: *filter-not-release-or-master
           requires:


### PR DESCRIPTION
**What this PR does**:

It removes the `security_scan` job from PRs' pipelines.

**Why do we need it**:

It's causing issues to / conflicting with community pull requests (like [here](https://github.com/grafana/grafana-image-renderer/pull/387#issuecomment-1330445915)) while I don't think it's that critical to keep it there - actually I don't think we continuously analyze (on a pull request basis) the output of those security scans, so I think keeping them only on master builds is enough.

In fact, that's what we do with Grafana's repo, if I'm not wrong.

**Special notes for your reviewer**: