### PR TITLE
Build on multiple architectures

### DIFF
--- a/scripts/build_push_docker.sh
+++ b/scripts/build_push_docker.sh
@@ -10,12 +10,11 @@ else
 fi
 
 echo "building ${TAG}"
-docker build -t ${IMAGE_NAME}:${TAG} .
-
 echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-docker push ${IMAGE_NAME}:${TAG}
-
+tags=()
+tags+=${IMAGE_NAME}:${TAG}
 if [[ $TAG != *"beta"* ]] && [[ $TAG != *"master"* ]]; then
-  docker tag ${IMAGE_NAME}:${TAG} ${IMAGE_NAME}:latest
-  docker push ${IMAGE_NAME}:latest
+  tags+={IMAGE_NAME}:latest
 fi
+
+docker buildx build --platform linux/amd64,linux/arm64 --push -t ${tags[@]} .


### PR DESCRIPTION
Currently, no ARM64 images are built. This changes the build script so that ARM64 as well as AMD64 images are built.

Disclaimer: This repo is using CircleCI instead of Github Actions to build, so I cannot test this except locally.

Fixes #7 