### PR TITLE
Fix error when req.failure() is null

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -537,7 +537,11 @@ export class Browser {
   };
 
   logRequestFailed = (req: any) => {
-    this.log.error('Browser request failed', 'url', req.url(), 'method', req.method(), 'failure', req.failure().errorText);
+    let failureError = ""
+    if (req.failure()) {
+      failureError = req.failure().errorText
+    }
+    this.log.error('Browser request failed', 'url', req.url(), 'method', req.method(), 'failure', failureError);
   };
 
   logRequestFinished = (req: any) => {

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -538,8 +538,9 @@ export class Browser {
 
   logRequestFailed = (req: any) => {
     let failureError = ""
-    if (req.failure()) {
-      failureError = req.failure().errorText
+    const failure = req?.failure();
+    if (failure) {
+      failureError = failure.errorText
     }
     this.log.error('Browser request failed', 'url', req.url(), 'method', req.method(), 'failure', failureError);
   };


### PR DESCRIPTION
Related: https://github.com/grafana/support-escalations/issues/5010

Looks like that `req.failure()` could be null and it fails when it happens.