### PR TITLE
Security: can set array of auth tokens

### DIFF
--- a/scripts/clean_target.sh
+++ b/scripts/clean_target.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+ARCH="${1:-}"
+OUT="${2:-}"
+
+if [ -z "$ARCH" ]; then
+    echo "ARCH (arg 1) has to be set"
+    exit 1
+fi
+
+PLUGIN_NAME=plugin-${ARCH}
+
+if [ ! -z "$OUT"  ]; then
+    PLUGIN_NAME=${OUT}
+fi
+
+rm -rf .dist/${PLUGIN_NAME}
+rm -f ./artifacts/${PLUGIN_NAME}.zip

--- a/src/app.ts
+++ b/src/app.ts
@@ -109,7 +109,8 @@ function populateServiceConfigFromEnv(config: ServiceConfig, env: NodeJS.Process
   }
 
   if (env['AUTH_TOKEN']) {
-    config.service.security.authToken = env['AUTH_TOKEN'];
+    const authToken = env['AUTH_TOKEN'] as string;
+    config.service.security.authToken = authToken.includes(' ') ? authToken.split(' ') : authToken;
   }
 
   if (env['LOG_LEVEL']) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -151,7 +151,7 @@ export const readJSONFileSync = (filePath: string): any => {
 
 export const isAuthTokenValid = (config: SecurityConfig, reqAuthToken: string): boolean => {
   let configToken = config.authToken || [''];
-  if (typeof configToken == "string") {
+  if (typeof configToken === "string") {
     configToken = [configToken]
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export interface LoggingConfig {
 }
 
 export interface SecurityConfig {
-  authToken: string;
+  authToken: string | string[];
 }
 
 export interface ServiceConfig {
@@ -148,3 +148,12 @@ export const readJSONFileSync = (filePath: string): any => {
   const rawdata = fs.readFileSync(filePath, 'utf8');
   return JSON.parse(rawdata);
 };
+
+export const isAuthTokenValid = (config: SecurityConfig, reqAuthToken: string): boolean => {
+  let configToken = config.authToken || [''];
+  if (typeof configToken == "string") {
+    configToken = [configToken]
+  }
+
+  return reqAuthToken !== "" && configToken.includes(reqAuthToken)
+}

--- a/src/service/middlewares.ts
+++ b/src/service/middlewares.ts
@@ -1,7 +1,7 @@
 import express = require('express');
 import * as boom from '@hapi/boom';
 import { ImageRenderOptions } from '../types';
-import { SecurityConfig } from '../config';
+import { SecurityConfig, isAuthTokenValid } from '../config';
 
 export const asyncMiddleware = (fn) => (req, res, next) => {
   Promise.resolve(fn(req, res, next)).catch((err) => {
@@ -28,10 +28,8 @@ export const trustedUrlMiddleware = (
 
 export const authTokenMiddleware = (config: SecurityConfig) => {
   return (req: express.Request<any, any, any, ImageRenderOptions, any>, res: express.Response, next: express.NextFunction) => {
-    const cfgToken = config.authToken || '';
     const headerToken = req.header('X-Auth-Token');
-
-    if (headerToken === undefined || headerToken !== cfgToken) {
+    if (headerToken === undefined || !isAuthTokenValid(config, headerToken)) {
       return next(boom.unauthorized('Unauthorized request'));
     }
 


### PR DESCRIPTION
To rotate authentication tokens in a distributed environment, updating the renderer token means breaking the rendering features in Grafana until the Grafana instances are updated with the right token.

Allowing to set up an array of authentication tokens allows to rotate tokens without downtime. 

Notes:
- In environment variables, tokens can be set as space delimited strings (as tokens could contain commas).
- Still support setting the auth token as a string to not introduce a breaking change.
