### PR TITLE
Fix fullpage waitFor conditions

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -339,8 +339,16 @@ export class Browser {
                * dashboard-row exists only in rows.
                */
               const panelCount = document.querySelectorAll('[data-panelId]').length;
-              const totalPanelsRendered = document.querySelectorAll('.panel-content').length + document.querySelectorAll('.dashboard-row').length;
-              return totalPanelsRendered === panelCount;
+              const panelsRendered = document.querySelectorAll('[class$=\'panel-content\']')
+              let panelsRenderedCount = 0
+              panelsRendered.forEach((value: Element) => {
+                if (value.childElementCount > 0) {
+                  panelsRenderedCount++
+                }
+              })
+
+              const totalPanelsRendered = panelsRenderedCount + document.querySelectorAll('.dashboard-row').length;
+              return totalPanelsRendered >= panelCount;
             }
 
             const panelCount = document.querySelectorAll('.panel').length || document.querySelectorAll('.panel-container').length;


### PR DESCRIPTION
Fix the condition to wait for all panels to load when doing a full dashboard page screenshot.

The current condition is not working so the timeout is reached every time we do a dashboard screenshot. 