### PR TITLE
Plugin: fix Chrome path

### DIFF
--- a/scripts/download_chrome.js
+++ b/scripts/download_chrome.js
@@ -1,5 +1,4 @@
 const { BrowserPlatform, Browser, install, resolveBuildId } = require('@puppeteer/browsers');
-const childProcess = require('child_process');
 const fs = require('fs')
 const path = require('path');
 
@@ -26,9 +25,6 @@ if (platform === 'darwin') {
 const outputPath = path.resolve(process.cwd(), 'dist', process.argv[3] || `plugin-${archArg}`);
 
 const browserVersion = Browser.CHROME;
-
-// Clean up download folder if exists
-childProcess.execFileSync('rm', ['-rf', `${outputPath}/chrome`]);
 
 async function download() {
     const buildId = await resolveBuildId(browserVersion, platform, 'latest');

--- a/scripts/download_chrome.js
+++ b/scripts/download_chrome.js
@@ -45,7 +45,8 @@ download().then(() => {
 
     // All the chrome files should be in the plugin 'chrome' folder
     // This is used to set the puppeteer.executablePath
-    const out = childProcess.execFileSync('find', [`${outputPath}/chrome`, '-type', 'f', '-name', 'chrome.exe', '-exec', 'dirname', '{}', '\;']);
+    const ext = platform === BrowserPlatform.WIN64 ? '.exe' : '';
+    const out = childProcess.execFileSync('find', [`${outputPath}/chrome`, '-type', 'f', '-name', `chrome${ext}`, '-exec', 'dirname', '{}', '\;']);
     const chromeBinDir = out.toString().trim()
     
     console.log(`Moving ${chromeBinDir} content into ${outputPath}/chrome`);

--- a/scripts/download_chrome.js
+++ b/scripts/download_chrome.js
@@ -1,5 +1,6 @@
 const { BrowserPlatform, Browser, install, resolveBuildId } = require('@puppeteer/browsers');
 const childProcess = require('child_process');
+const fs = require('fs')
 const path = require('path');
 
 const archArg = process.argv[2];
@@ -40,17 +41,9 @@ async function download() {
     });
 }
 
-download().then(() => {
+download().then(browser => {
     console.log(`${browserVersion} downloaded into:`, outputPath);
 
-    // All the chrome files should be in the plugin 'chrome' folder
-    // This is used to set the puppeteer.executablePath
-    const ext = platform === BrowserPlatform.WIN64 ? '.exe' : '';
-    const out = childProcess.execFileSync('find', [`${outputPath}/chrome`, '-type', 'f', '-name', `chrome${ext}`, '-exec', 'dirname', '{}', '\;']);
-    const chromeBinDir = out.toString().trim()
-    
-    console.log(`Moving ${chromeBinDir} content into ${outputPath}/chrome`);
-    childProcess.execFileSync('mv', [chromeBinDir, `${outputPath}/tmp`]);
-    childProcess.execFileSync('rm', ['-r', `${outputPath}/chrome`]);
-    childProcess.execFileSync('mv', [`${outputPath}/tmp`, `${outputPath}/chrome`]);
+    const chromeInfo = { buildId: browser.buildId };
+    return fs.writeFileSync(path.resolve(outputPath, 'chrome-info.json'), JSON.stringify(chromeInfo));
 });

--- a/scripts/download_chrome.js
+++ b/scripts/download_chrome.js
@@ -27,7 +27,7 @@ const outputPath = path.resolve(process.cwd(), 'dist', process.argv[3] || `plugi
 const browserVersion = Browser.CHROME;
 
 // Clean up download folder if exists
-childProcess.execSync(`rm -rf "${outputPath}/chrome"`);
+childProcess.execFileSync('rm', ['-rf', `${outputPath}/chrome`]);
 
 async function download() {
     const buildId = await resolveBuildId(browserVersion, platform, 'latest');
@@ -45,11 +45,11 @@ download().then(() => {
 
     // All the chrome files should be in the plugin 'chrome' folder
     // This is used to set the puppeteer.executablePath
-    const out = childProcess.execSync(`find ${outputPath}/chrome -type f -name chrome.exe -exec dirname "{}" \;`);
+    const out = childProcess.execFileSync('find', [`${outputPath}/chrome`, '-type', 'f', '-name', 'chrome.exe', '-exec', 'dirname', '{}', '\;']);
     const chromeBinDir = out.toString().trim()
     
-    console.log(`Moving ${chromeBinDir} content into ${outputPath}/chrome`)
-    childProcess.execSync(`mv ${chromeBinDir} ${outputPath}/tmp`)
-    childProcess.execSync(`rm -r "${outputPath}/chrome"`);
-    childProcess.execSync(`mv "${outputPath}/tmp" "${outputPath}/chrome"`);
+    console.log(`Moving ${chromeBinDir} content into ${outputPath}/chrome`);
+    childProcess.execFileSync('mv', [chromeBinDir, `${outputPath}/tmp`]);
+    childProcess.execFileSync('rm', ['-r', `${outputPath}/chrome`]);
+    childProcess.execFileSync('mv', [`${outputPath}/tmp`, `${outputPath}/chrome`]);
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as _ from 'lodash';
+import * as os from 'os';
 import { RenderGRPCPluginV2 } from './plugin/v2/grpc_plugin';
 import { HttpServer } from './service/http-server';
 import { ConsoleLogger, PluginLogger } from './logger';
@@ -18,7 +19,8 @@ async function main() {
     const config: PluginConfig = defaultPluginConfig;
     populatePluginConfigFromEnv(config, env);
     if (!config.rendering.chromeBin && (process as any).pkg) {
-      config.rendering.chromeBin = [path.dirname(process.execPath), 'chrome', 'chrome.exe'].join(path.sep);
+      const ext = os.platform() === 'win32' ? '.exe' : ''
+      config.rendering.chromeBin = [path.dirname(process.execPath), 'chrome', `chrome${ext}`].join(path.sep);
       logger.debug(`Setting chromeBin to ${config.rendering.chromeBin}`);
     }
 

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -240,10 +240,6 @@ class PluginGRPCServer {
 const populateConfigFromEnv = (config: PluginConfig) => {
   const env = Object.assign({}, process.env);
 
-  if (env['GF_PLUGIN_RENDERING_CHROME_BIN']) {
-    config.rendering.chromeBin = env['GF_PLUGIN_RENDERING_CHROME_BIN'];
-  }
-
   if (env['GF_PLUGIN_RENDERING_ARGS']) {
     const args = env['GF_PLUGIN_RENDERING_ARGS'] as string;
     if (args.length > 0) {


### PR DESCRIPTION
The Puppeteer update (https://github.com/grafana/grafana-image-renderer/pull/433) contained an update to the `puppeteer.executablePath` function used in plugin mode to compute Chrome executable path. 

This PR updates the package scripts to ensure Chrome is always installed under `<pluginDir>/chrome` so we can use this path in plugin mode. 

Fixes https://github.com/grafana/grafana-image-renderer/issues/449