### PR TITLE
Chore: Fix release notes

### DIFF
--- a/scripts/publish_github_release.sh
+++ b/scripts/publish_github_release.sh
@@ -4,7 +4,7 @@ set -e
 
 git fetch --tags
 
-RELEASE_NOTES=$(awk 'BEGIN {FS="##"; RS=""} FNR==2 {print; exit}' CHANGELOG.md)
+RELEASE_NOTES=$(awk 'BEGIN {FS="##"; RS=""} FNR==1 {print; exit}' CHANGELOG.md)
 VERSION=$(cat plugin.json|jq '.info.version'| sed s/\"//g)
 PRERELEASE=''
 LATEST_TAG=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
When making a release, the changelog for the latest version is wrong (the changelog for the previous version is used). This PR should fix this.

Fixes https://github.com/grafana/grafana-image-renderer/issues/427