### PR TITLE
Browser: Revert to old headless mode

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,9 @@ async function main() {
   const env = Object.assign({}, process.env);
   const command = argv._[0];
 
+  // See https://github.com/grafana/grafana-image-renderer/issues/460
+  process.env["PUPPETEER_DISABLE_HEADLESS_WARNING"] = "true"
+
   if (command === undefined) {
     const logger = new PluginLogger();
     const config: PluginConfig = defaultPluginConfig;
@@ -24,7 +27,7 @@ async function main() {
       const chromeInfoFile = fs.readFileSync(path.resolve(execPath, 'chrome-info.json'), 'utf8');
       const chromeInfo = JSON.parse(chromeInfoFile);
 
-     config.rendering.chromeBin = computeExecutablePath({
+      config.rendering.chromeBin = computeExecutablePath({
         cacheDir: path.dirname(process.execPath),
         browser: Browser.CHROME,
         buildId: chromeInfo.buildId,

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -135,7 +135,7 @@ export class Browser {
       launcherOptions.executablePath = this.config.chromeBin;
     }
 
-    launcherOptions.headless = !this.config.headed ? "new" : false;
+    launcherOptions.headless = !this.config.headed;
 
     return launcherOptions;
   }


### PR DESCRIPTION
This PR reverts a change from https://github.com/grafana/grafana-image-renderer/pull/433

The [new headless](https://developer.chrome.com/articles/new-headless/) mode for Chrome is known to have some issues including [one](https://github.com/puppeteer/puppeteer/issues/10829) that seems to make Chrome crash when using Kubernetes. 

As this prevents several Kubernetes users to upgrade their grafana-image-renderer, it's best to revert to the old headless mode until there is more information regarding the issues above.

Fixes https://github.com/grafana/grafana-image-renderer/issues/458 and https://github.com/grafana/grafana-image-renderer/issues/450