### PR TITLE
Fix issue of timezone config being always overwritten

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -104,7 +104,7 @@ function populatePluginConfigFromEnv(config: PluginConfig, env: NodeJS.ProcessEn
 function populateServiceConfigFromEnv(config: ServiceConfig, env: NodeJS.ProcessEnv) {
   if (env['BROWSER_TZ']) {
     config.rendering.timezone = env['BROWSER_TZ'];
-  } else {
+  } else if (env['TZ']) {
     config.rendering.timezone = env['TZ'];
   }
 


### PR DESCRIPTION
The [`timezone` config](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#default-timezone) is not working since it's always being overwritten by env variables even if `env['TZ']` is unset/null. 

This fixes the issue to enable `timezone` config properly recognized by runtime