### PR TITLE
Revert "Fix check condition to avoid timeouts in invalid panels (#299)"

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -352,7 +352,7 @@ export class Browser {
             }
 
             const panelCount = document.querySelectorAll('.panel').length || document.querySelectorAll('.panel-container').length;
-            return (window as any).panelsRendered >= panelCount || (window as any).panelsRendered === undefined;
+            return (window as any).panelsRendered >= panelCount;
           },
           {
             timeout: options.timeout * 1000,


### PR DESCRIPTION
This reverts commit eae4793d5f5c098ad97f813a4f30885079903bed.

`panelsRendered` is actually always undefined before the panel is rendered. This issue should be fixed in Grafana, I opened the following PR to do so: https://github.com/grafana/grafana/pull/75885