### PR TITLE
Drone: Fix push to Docker step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,9 +51,9 @@ steps:
   name: security-scan
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc
+  - ./scripts/package_target.sh linux-x64-glibc
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc || true
-  - sh scripts/archive_target.sh linux-x64-glibc
+  - ./scripts/archive_target.sh linux-x64-glibc
   depends_on:
   - yarn-build
   environment:
@@ -63,9 +63,9 @@ steps:
   name: package-linux-x64-glibc
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh darwin-x64-unknown
+  - ./scripts/package_target.sh darwin-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-darwin-x64-unknown || true
-  - sh scripts/archive_target.sh darwin-x64-unknown
+  - ./scripts/archive_target.sh darwin-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -75,9 +75,9 @@ steps:
   name: package-darwin-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh win32-x64-unknown
+  - ./scripts/package_target.sh win32-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-win32-x64-unknown || true
-  - sh scripts/archive_target.sh win32-x64-unknown
+  - ./scripts/archive_target.sh win32-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -87,10 +87,10 @@ steps:
   name: package-win32-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
+  - ./scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc-no-chromium ||
     true
-  - sh scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
+  - ./scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
   depends_on:
   - yarn-build
   environment:
@@ -159,9 +159,9 @@ steps:
   name: security-scan
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc
+  - ./scripts/package_target.sh linux-x64-glibc
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc
-  - sh scripts/archive_target.sh linux-x64-glibc
+  - ./scripts/archive_target.sh linux-x64-glibc
   depends_on:
   - yarn-build
   environment:
@@ -171,9 +171,9 @@ steps:
   name: package-linux-x64-glibc
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh darwin-x64-unknown
+  - ./scripts/package_target.sh darwin-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-darwin-x64-unknown
-  - sh scripts/archive_target.sh darwin-x64-unknown
+  - ./scripts/archive_target.sh darwin-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -183,9 +183,9 @@ steps:
   name: package-darwin-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh win32-x64-unknown
+  - ./scripts/package_target.sh win32-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-win32-x64-unknown
-  - sh scripts/archive_target.sh win32-x64-unknown
+  - ./scripts/archive_target.sh win32-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -195,9 +195,9 @@ steps:
   name: package-win32-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
+  - ./scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc-no-chromium
-  - sh scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
+  - ./scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
   depends_on:
   - yarn-build
   environment:
@@ -206,7 +206,7 @@ steps:
   image: grafana/grafana-plugin-ci:1.9.0
   name: package-linux-x64-glibc-no-chromium
 - commands:
-  - sh scripts/build_push_docker.sh master
+  - ./scripts/build_push_docker.sh master
   environment:
     DOCKER_PASS:
       from_secret: docker_pass
@@ -281,9 +281,9 @@ steps:
   name: security-scan
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc
+  - ./scripts/package_target.sh linux-x64-glibc
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc
-  - sh scripts/archive_target.sh linux-x64-glibc
+  - ./scripts/archive_target.sh linux-x64-glibc
   depends_on:
   - yarn-build
   environment:
@@ -293,9 +293,9 @@ steps:
   name: package-linux-x64-glibc
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh darwin-x64-unknown
+  - ./scripts/package_target.sh darwin-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-darwin-x64-unknown
-  - sh scripts/archive_target.sh darwin-x64-unknown
+  - ./scripts/archive_target.sh darwin-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -305,9 +305,9 @@ steps:
   name: package-darwin-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh win32-x64-unknown
+  - ./scripts/package_target.sh win32-x64-unknown
   - bin/grabpl build-plugin-manifest ./dist/plugin-win32-x64-unknown
-  - sh scripts/archive_target.sh win32-x64-unknown
+  - ./scripts/archive_target.sh win32-x64-unknown
   depends_on:
   - yarn-build
   environment:
@@ -317,9 +317,9 @@ steps:
   name: package-win32-x64-unknown
 - commands:
   - . ~/.init-nvm.sh
-  - sh scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
+  - ./scripts/package_target.sh linux-x64-glibc true plugin-linux-x64-glibc-no-chromium
   - bin/grabpl build-plugin-manifest ./dist/plugin-linux-x64-glibc-no-chromium
-  - sh scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
+  - ./scripts/archive_target.sh linux-x64-glibc plugin-linux-x64-glibc-no-chromium
   depends_on:
   - yarn-build
   environment:
@@ -328,8 +328,8 @@ steps:
   image: grafana/grafana-plugin-ci:1.9.0
   name: package-linux-x64-glibc-no-chromium
 - commands:
-  - sh scripts/generate_md5sum.sh
-  - sh scripts/publish_github_release.sh
+  - ./scripts/generate_md5sum.sh
+  - ./scripts/publish_github_release.sh
   depends_on:
   - package-linux-x64-glibc
   - package-darwin-x64-unknown
@@ -341,7 +341,7 @@ steps:
   image: cibuilds/github:0.13.0
   name: publish_to_github
 - commands:
-  - sh scripts/build_push_docker.sh
+  - ./scripts/build_push_docker.sh
   depends_on:
   - publish_to_github
   environment:
@@ -358,7 +358,7 @@ steps:
 - commands:
   - . ~/.init-nvm.sh
   - yarn run create-gcom-plugin-json ${DRONE_COMMIT}
-  - sh scripts/push-to-gcom.sh
+  - ./scripts/push-to-gcom.sh
   depends_on:
   - publish_to_github
   environment:
@@ -414,6 +414,6 @@ kind: secret
 name: srcclr_api_token
 ---
 kind: signature
-hmac: e6b99f052740c6862015a124564b85182f9877f4eccc159334a40000faf3a008
+hmac: f130230eb86344632de732a9fa4fe1155c622537fbe3c61d9fc1d8b17a4cacea
 
 ...

--- a/scripts/build_push_docker.sh
+++ b/scripts/build_push_docker.sh
@@ -12,10 +12,9 @@ fi
 
 echo "building ${TAG}"
 echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-tags=()
-tags+=${IMAGE_NAME}:${TAG}
+tags=("-t ${IMAGE_NAME}:${TAG}")
 if [ -z "$(echo $TAG | grep -E "beta|master")" ]; then
-  tags+={IMAGE_NAME}:latest
+  tags+=("-t ${IMAGE_NAME}:latest")
 fi
 
-# docker buildx build --platform linux/amd64,linux/arm64 --push -t ${tags[@]} .
+docker buildx build --platform linux/amd64,linux/arm64 --push ${tags[@]} .

--- a/scripts/build_push_docker.sh
+++ b/scripts/build_push_docker.sh
@@ -18,4 +18,4 @@ if [ -z "$(echo $TAG | grep -E "beta|master")" ]; then
   tags+={IMAGE_NAME}:latest
 fi
 
-docker buildx build --platform linux/amd64,linux/arm64 --push -t ${tags[@]} .
+# docker buildx build --platform linux/amd64,linux/arm64 --push -t ${tags[@]} .

--- a/scripts/drone/common.star
+++ b/scripts/drone/common.star
@@ -28,9 +28,9 @@ def build_step():
     }
 
 def package_step(arch, name='', skip_chromium=False, override_output='', skip_errors=True):
-    pkg_cmd = 'sh scripts/package_target.sh {}'.format(arch)
+    pkg_cmd = './scripts/package_target.sh {}'.format(arch)
     bpm_cmd = 'bin/grabpl build-plugin-manifest ./dist/'
-    arc_cmd = 'sh scripts/archive_target.sh {}'.format(arch)
+    arc_cmd = './scripts/archive_target.sh {}'.format(arch)
 
     if skip_chromium:
         pkg_cmd += ' true {}'.format(override_output)

--- a/scripts/drone/promotion.star
+++ b/scripts/drone/promotion.star
@@ -6,8 +6,8 @@ def publish_gh_release():
         'name': 'publish_to_github',
         'image': 'cibuilds/github:0.13.0',
         'commands': [
-            'sh scripts/generate_md5sum.sh',
-            'sh scripts/publish_github_release.sh',
+            './scripts/generate_md5sum.sh',
+            './scripts/publish_github_release.sh',
         ],
         'environment': {
             'GITHUB_TOKEN': from_secret('github_token'),
@@ -40,7 +40,7 @@ def publish_to_docker():
             'DOCKER_USER': from_secret('docker_user'),
             'DOCKER_PASS': from_secret('docker_pass'),
         },
-        'commands': ['sh scripts/build_push_docker.sh'],
+        'commands': ['./scripts/build_push_docker.sh'],
         'volumes': [{'name': 'docker', 'path': '/var/run/docker.sock'}],
     }
 
@@ -51,7 +51,7 @@ def publish_to_gcom():
         'commands': [
             '. ~/.init-nvm.sh',
             'yarn run create-gcom-plugin-json ${DRONE_COMMIT}',
-            'sh scripts/push-to-gcom.sh',
+            './scripts/push-to-gcom.sh',
         ],
         'environment': {
             'GCOM_URL': from_secret('gcom_url'),


### PR DESCRIPTION
Switch all scripts execution to be executed with /bin/bash instead of sh. This fixes the [Drone current failure](https://drone.grafana.net/grafana/grafana-image-renderer/194/1/10) as the sh shell has no syntax to create arrays, but Bash has.