### PR TITLE
Drone: Fix docker buildx usage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -213,7 +213,7 @@ steps:
     DOCKER_USER:
       from_secret: docker_user
     IMAGE_NAME: grafana/grafana-image-renderer
-  image: google/cloud-sdk:412.0.0
+  image: google/cloud-sdk:449.0.0
   name: publish_to_docker_master
   volumes:
   - name: docker
@@ -350,7 +350,7 @@ steps:
     DOCKER_USER:
       from_secret: docker_user
     IMAGE_NAME: grafana/grafana-image-renderer
-  image: google/cloud-sdk:412.0.0
+  image: google/cloud-sdk:449.0.0
   name: publish_to_docker
   volumes:
   - name: docker
@@ -414,6 +414,6 @@ kind: secret
 name: srcclr_api_token
 ---
 kind: signature
-hmac: f130230eb86344632de732a9fa4fe1155c622537fbe3c61d9fc1d8b17a4cacea
+hmac: eeb3dd651cc32e9e32188e7f904e97131911d9699c7610c4b33a19098c257d9f
 
 ...

--- a/scripts/build_push_docker.sh
+++ b/scripts/build_push_docker.sh
@@ -17,4 +17,9 @@ if [ -z "$(echo $TAG | grep -E "beta|master")" ]; then
   tags+=("-t ${IMAGE_NAME}:latest")
 fi
 
+# The default Docker builder does not support multiple platforms, so this creates a non-default builder that does support multiple platforms.
+if ! docker buildx inspect | grep -E 'Driver:\s+docker-container' >/dev/null; then
+  docker buildx create --use
+fi
+
 docker buildx build --platform linux/amd64,linux/arm64 --push ${tags[@]} .

--- a/scripts/drone/promotion.star
+++ b/scripts/drone/promotion.star
@@ -34,7 +34,7 @@ def publish_to_docker_release():
 def publish_to_docker():
     return {
         'name': 'publish_to_docker',
-        'image': 'google/cloud-sdk:412.0.0',
+        'image': 'google/cloud-sdk:449.0.0',
         'environment': {
             'IMAGE_NAME': docker_image,
             'DOCKER_USER': from_secret('docker_user'),


### PR DESCRIPTION
Based on https://github.com/grafana/grafana-image-renderer/pull/470

This PR upgrade the base image to build Docker images to be able to use `docker buildx`. Plus this creates a non-default Docker builder to be able to build for multiple platforms. 