### PR TITLE
Doc: Update link to Grafana documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ grafana-cli plugins install grafana-image-renderer
 
 This plugin is not compatible with the current Grafana Docker image and requires additional system-level dependencies. We recommend setting up another Docker container for rendering and using remote rendering instead. For instruction, refer to [Run in Docker](#run-in-docker).
 
-If you still want to install the plugin with the Grafana Docker image, refer to the instructions on building a custom Grafana image in [Grafana Docker documentation](https://grafana.com/docs/installation/docker/#custom-image-with-grafana-image-renderer-plugin-pre-installed).
+If you still want to install the plugin with the Grafana Docker image, refer to the instructions on building a custom Grafana image in [Grafana Docker documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#build-a-custom-grafana-docker-image).
 
 ## Remote rendering service installation
 


### PR DESCRIPTION
The link toward Grafana documentation is currently broken, it brings to the generic documentation on Docker and not the one that describes how to build a custom image.