### PR TITLE
WaitingForPanels: Change waiting logic

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -328,7 +328,7 @@ export class Browser {
           this.log.debug('Waiting for dashboard/panel to load', 'timeout', `${options.timeout}s`);
         }
 
-        await page.waitForNetworkIdle();
+        await page.waitForNetworkIdle({ timeout: options.timeout * 1000 });
         await new Promise((resolve) => setTimeout(resolve, 100));
       }, 'panelsRendered');
     } catch (err) {


### PR DESCRIPTION
This improves and simplifies the waiting for panel queries and panel rendering logic. 

Instead of scanning for how many panels there are using css selectors and comparing this to panel content (which is a bit unreliable / fragile) we just wait for all network requests to be completed and then an additional 100ms for data rendering (this step should be blocking so maybe we can lower this). 

* [x] Now the waiting for panels step also works in scenes
* [x] Tested with single panels
* [x] Tested with full dashboard images (using height=-1)  (With many slow queries)
* [x] Tested with new and angular panels 