### PR TITLE
Update image to run tests in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,8 @@ clone:
   retries: 3
 depends_on: []
 image_pull_secrets:
-- dockerconfigjson
+- gcr
+- gar
 kind: pipeline
 name: test-pr
 node:
@@ -45,14 +46,14 @@ steps:
   image: jwilder/dockerize:0.6.1
   name: wait-for-grafana
 - commands:
-  - yarn test
+  - yarn test-ci
   depends_on:
   - wait-for-grafana
   - yarn-build
   environment:
     CI: "true"
     PUPPETEER_CACHE_DIR: /drone/src/cache
-  image: grafana/docker-puppeteer:pre-node-20
+  image: us-docker.pkg.dev/grafanalabs-dev/grafana-ci/docker-puppeteer:2.0.0
   name: yarn-test
 - commands:
   - . ~/.init-nvm.sh
@@ -132,7 +133,8 @@ clone:
   retries: 3
 depends_on: []
 image_pull_secrets:
-- dockerconfigjson
+- gcr
+- gar
 kind: pipeline
 name: test-master
 node:
@@ -174,14 +176,14 @@ steps:
   image: jwilder/dockerize:0.6.1
   name: wait-for-grafana
 - commands:
-  - yarn test
+  - yarn test-ci
   depends_on:
   - wait-for-grafana
   - yarn-build
   environment:
     CI: "true"
     PUPPETEER_CACHE_DIR: /drone/src/cache
-  image: grafana/docker-puppeteer:pre-node-20
+  image: us-docker.pkg.dev/grafanalabs-dev/grafana-ci/docker-puppeteer:2.0.0
   name: yarn-test
 - commands:
   - . ~/.init-nvm.sh
@@ -277,7 +279,8 @@ clone:
   retries: 3
 depends_on: []
 image_pull_secrets:
-- dockerconfigjson
+- gcr
+- gar
 kind: pipeline
 name: release
 node:
@@ -319,14 +322,14 @@ steps:
   image: jwilder/dockerize:0.6.1
   name: wait-for-grafana
 - commands:
-  - yarn test
+  - yarn test-ci
   depends_on:
   - wait-for-grafana
   - yarn-build
   environment:
     CI: "true"
     PUPPETEER_CACHE_DIR: /drone/src/cache
-  image: grafana/docker-puppeteer:pre-node-20
+  image: us-docker.pkg.dev/grafanalabs-dev/grafana-ci/docker-puppeteer:2.0.0
   name: yarn-test
 - commands:
   - . ~/.init-nvm.sh
@@ -452,7 +455,7 @@ get:
   name: .dockerconfigjson
   path: secret/data/common/gcr
 kind: secret
-name: dockerconfigjson
+name: gcr
 ---
 get:
   name: github_token
@@ -478,7 +481,13 @@ get:
 kind: secret
 name: srcclr_api_token
 ---
+get:
+  name: .dockerconfigjson
+  path: secret/data/common/gar
+kind: secret
+name: gar
+---
 kind: signature
-hmac: f6cb2de5719e26d46b642bb10f322f1b269310d013408b72a0d72b1c05d4ebea
+hmac: 04abae61fca21a27f8b24027ca87a9c8e54b06200f089e058641076fd3ef2300
 
 ...

--- a/scripts/drone/utils.star
+++ b/scripts/drone/utils.star
@@ -1,4 +1,4 @@
-load('scripts/drone/vault.star', 'pull_secret')
+load('scripts/drone/vault.star', 'gcr_pull_secret', 'gar_pull_secret')
 
 ci_image = 'grafana/grafana-plugin-ci:1.9.0'
 docker_image = 'grafana/grafana-image-renderer'
@@ -49,7 +49,7 @@ def pipeline(
             }
         ],
         'depends_on': depends_on,
-        'image_pull_secrets': [pull_secret],
+        'image_pull_secrets': [gcr_pull_secret, gar_pull_secret],
     }
     if environment:
         pipeline.update(

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -1,4 +1,5 @@
-pull_secret = 'dockerconfigjson'
+gcr_pull_secret = "gcr"
+gar_pull_secret = "gar"
 
 def from_secret(secret):
     return {'from_secret': secret}
@@ -15,9 +16,10 @@ def vault_secret(name, path, key):
 
 def secrets():
     return [
-        vault_secret(pull_secret, 'secret/data/common/gcr', '.dockerconfigjson'),
+        vault_secret(gcr_pull_secret, 'secret/data/common/gcr', '.dockerconfigjson'),
         vault_secret('github_token', 'infra/data/ci/drone-plugins', 'github_token'),
         vault_secret('gcom_publish_token', 'infra/data/ci/drone-plugins', 'gcom_publish_token'),
         vault_secret('grafana_api_key', 'infra/data/ci/drone-plugins', 'grafana_api_key'),
         vault_secret('srcclr_api_token', 'infra/data/ci/drone-plugins', 'srcclr_api_token'),
+        vault_secret(gar_pull_secret, 'secret/data/common/gar', '.dockerconfigjson'),
     ]


### PR DESCRIPTION
In [my last PR](https://github.com/grafana/grafana-image-renderer/pull/479) to introduce tests for the image renderer, I forgot to run `make drone` at the end, so we were still using the non-officially released image `grafana/docker-puppeteer:pre-node-20`.

This PR replaces it with the published `us-docker.pkg.dev/grafanalabs-dev/grafana-ci/docker-puppeteer:2.0.0` image. The content is the same but it's the correct way to use the image and it will help us in the future if we release new versions of this image (as they won't be available on Docker). 