### PR TITLE
PDF: Fix resolution when zooming in

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -354,6 +354,13 @@ export class Browser {
 
       if (isPDF) {
         const scale = parseFloat((options.deviceScaleFactor as string) || '1') || 1;
+        if (scale < 1) {
+          await this.setViewport(page, {
+            ...options,
+            deviceScaleFactor: 1 / scale,
+          });
+        }
+
         return page.pdf({
           ...getPDFOptionsFromURL(options.url),
           margin: {


### PR DESCRIPTION
When we wanted to zoom in on the PDF, the resolution was bad because we printed with a scale > 100%.

This viewport zoom fixes this.