### PR TITLE
Packages: Release Alpine package without Chromium

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -439,6 +439,7 @@ steps:
   - package-darwin-x64-unknown
   - package-win32-x64-unknown
   - package-linux-x64-glibc-no-chromium
+  - package-alpine-x64-no-chromium
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -524,6 +525,6 @@ kind: secret
 name: gar
 ---
 kind: signature
-hmac: 319cd4f70f7d6fc505eaeabd6177abcf1052a3b0658bf91fb5f78b847eea144a
+hmac: a1dd3abdcd3cbaa8c32ce086ed19f7556b0304d3f05f826baef2ed7729ae29a3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -120,6 +120,18 @@ steps:
       from_secret: grafana_api_key
   image: grafana/grafana-plugin-ci:1.9.0
   name: package-linux-x64-glibc-no-chromium
+- commands:
+  - . ~/.init-nvm.sh
+  - ./scripts/package_target.sh alpine-x64-unknown true plugin-alpine-x64-no-chromium
+  - bin/grabpl build-plugin-manifest ./dist/plugin-alpine-x64-no-chromium || true
+  - ./scripts/archive_target.sh alpine-x64-unknown plugin-alpine-x64-no-chromium
+  depends_on:
+  - yarn-test
+  environment:
+    GRAFANA_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-plugin-ci:1.9.0
+  name: package-alpine-x64-no-chromium
 trigger:
   event:
   - pull_request
@@ -249,6 +261,18 @@ steps:
       from_secret: grafana_api_key
   image: grafana/grafana-plugin-ci:1.9.0
   name: package-linux-x64-glibc-no-chromium
+- commands:
+  - . ~/.init-nvm.sh
+  - ./scripts/package_target.sh alpine-x64-unknown true plugin-alpine-x64-no-chromium
+  - bin/grabpl build-plugin-manifest ./dist/plugin-alpine-x64-no-chromium
+  - ./scripts/archive_target.sh alpine-x64-unknown plugin-alpine-x64-no-chromium
+  depends_on:
+  - yarn-test
+  environment:
+    GRAFANA_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-plugin-ci:1.9.0
+  name: package-alpine-x64-no-chromium
 - commands:
   - ./scripts/build_push_docker.sh master
   depends_on:
@@ -396,6 +420,18 @@ steps:
   image: grafana/grafana-plugin-ci:1.9.0
   name: package-linux-x64-glibc-no-chromium
 - commands:
+  - . ~/.init-nvm.sh
+  - ./scripts/package_target.sh alpine-x64-unknown true plugin-alpine-x64-no-chromium
+  - bin/grabpl build-plugin-manifest ./dist/plugin-alpine-x64-no-chromium
+  - ./scripts/archive_target.sh alpine-x64-unknown plugin-alpine-x64-no-chromium
+  depends_on:
+  - yarn-test
+  environment:
+    GRAFANA_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-plugin-ci:1.9.0
+  name: package-alpine-x64-no-chromium
+- commands:
   - ./scripts/generate_md5sum.sh
   - ./scripts/publish_github_release.sh
   depends_on:
@@ -488,6 +524,6 @@ kind: secret
 name: gar
 ---
 kind: signature
-hmac: 04abae61fca21a27f8b24027ca87a9c8e54b06200f089e058641076fd3ef2300
+hmac: 319cd4f70f7d6fc505eaeabd6177abcf1052a3b0658bf91fb5f78b847eea144a
 
 ...

--- a/scripts/drone/pipeline.star
+++ b/scripts/drone/pipeline.star
@@ -15,6 +15,7 @@ def common_steps(skip_errors):
         package_step(arch='darwin-x64-unknown', skip_errors=skip_errors),
         package_step(arch='win32-x64-unknown', skip_errors=skip_errors),
         package_step(arch='linux-x64-glibc', name='package-linux-x64-glibc-no-chromium', skip_chromium=True, override_output='plugin-linux-x64-glibc-no-chromium', skip_errors=skip_errors),
+        package_step(arch='alpine-x64-unknown', name='package-alpine-x64-no-chromium', skip_chromium=True, override_output='plugin-alpine-x64-no-chromium', skip_errors=skip_errors),
     ]
 
 def prs_pipeline():

--- a/scripts/drone/promotion.star
+++ b/scripts/drone/promotion.star
@@ -17,6 +17,7 @@ def publish_gh_release():
             'package-darwin-x64-unknown',
             'package-win32-x64-unknown',
             'package-linux-x64-glibc-no-chromium',
+            'package-alpine-x64-no-chromium',
         ],
     }
 


### PR DESCRIPTION
Since Alpine released its latest version (3.19.x), the Linux plugin that runs with `glibc` has not been working anymore. To fix this, we should replace `glibc` with `gcompat`, but this could break support for other plugins. Hence, this seems better to release a new package.

This can't replace the Linux package because it doesn't work on Linux distributions that don't work with `musl` (tested on OpenSUSE and it's not working, I guess it would be the same on RHEL). 

Part of fixing https://github.com/grafana/grafana-image-renderer/issues/505 (Once this PR is merged, this should be updated to use it: https://github.com/grafana/grafana/blob/main/packaging/docker/custom/Dockerfile#L37)

Another solution could be to switch the Grafana image used in the [custom image](https://github.com/grafana/grafana/blob/main/packaging/docker/custom/Dockerfile) we are providing to `grafana/grafana:${GRAFANA_VERSION}-ubuntu` and stop supporting Alpine custom images. 