### PR TITLE
HTTP Server: Fix CSV deletion

### DIFF
--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -296,12 +296,17 @@ export class HttpServer {
       } else {
         try {
           this.log.debug('Deleting temporary file', 'file', result.filePath);
-          fs.unlinkSync(result.filePath);
-          if (!options.filePath) {
-            fs.rmdirSync(path.dirname(result.filePath));
-          }
+          fs.unlink(result.filePath, (err) => {
+            if (err) {
+              throw err
+            }
+
+            if (!options.filePath) {
+              fs.rmdir(path.dirname(result.filePath), () => {});
+            }
+          })
         } catch (e) {
-          this.log.error('Failed to delete temporary file', 'file', result.filePath);
+          this.log.error('Failed to delete temporary file', 'file', result.filePath, 'error', e.message);
         }
       }
     });


### PR DESCRIPTION
I'm not sure why but the `fs.unlinkSync` function seems to return before the file is really deleted, causing the folder deletion to fail because it's not empty. The file is properly deleted but the folder stays there. This PR fixes this issue.