### PR TITLE
HTTPS: Fix creation when host is not defined

### DIFF
--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -164,7 +164,7 @@ export class HttpServer {
         this.log.info(`${protocol?.toUpperCase()} Server started, listening at ${protocol}://${host}:${info.port}`);
       });
     } else {
-      this.server = this.app.listen(port, () => {
+      this.server.listen(port, () => {
         const info = this.server.address() as net.AddressInfo;
         this.log.info(`${protocol?.toUpperCase()} Server started, listening at ${protocol}://localhost:${info.port}`);
       });


### PR DESCRIPTION
I refactored my code a bit at the end of my work on adding HTTPS support https://github.com/grafana/grafana-image-renderer/pull/527 breaking the behavior when `host` is not defined. This fixes it. 