### PR TITLE
Chore: Don't install DevPackages in docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM base as build
 
 COPY . ./
 
-RUN yarn install --pure-lockfile
+RUN yarn install --pure-lockfile --production=true
 RUN yarn run build
 
 EXPOSE 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Base stage
 FROM node:18-alpine AS base
 
 ENV CHROME_BIN="/usr/bin/chromium-browser"
@@ -5,22 +6,29 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 
 WORKDIR /usr/src/app
 
-RUN \
-  apk --no-cache upgrade && \
-  apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init && \
-  rm -rf /tmp/*
+RUN apk --no-cache upgrade && \
+    apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init && \
+    rm -rf /tmp/*
 
-FROM base as build
+# Development dependencies stage
+FROM base AS dev-dependencies
+
+COPY package.json yarn.lock ./
+RUN yarn install --pure-lockfile
+
+# Build stage
+FROM dev-dependencies AS build
 
 COPY . ./
-
-RUN yarn install --pure-lockfile --production=true
 RUN yarn run build
 
-EXPOSE 8081
+# Production dependencies stage
+FROM base AS prod-dependencies
 
-CMD [ "yarn", "run", "dev" ]
+COPY package.json yarn.lock ./
+RUN yarn install --pure-lockfile --production
 
+# Final stage
 FROM base
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
@@ -38,7 +46,7 @@ RUN addgroup -S -g $GF_GID grafana && \
 
 ENV NODE_ENV=production
 
-COPY --from=build /usr/src/app/node_modules node_modules
+COPY --from=prod-dependencies /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/build build
 COPY --from=build /usr/src/app/proto proto
 COPY --from=build /usr/src/app/default.json config.json


### PR DESCRIPTION
To remove possible security concern points I want to remove installing devPackages which are not needed in docker image.

Any suggestion is highly anticipated