### PR TITLE
Full page image: Fix blank page 

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -130,6 +130,7 @@ export class Browser {
       ignoreHTTPSErrors: this.config.ignoresHttpsErrors,
       dumpio: this.config.dumpio,
       args: this.config.args,
+      defaultViewport: null
     };
 
     if (this.config.chromeBin) {
@@ -397,7 +398,7 @@ export class Browser {
         });
       }
 
-      return page.screenshot({ path: options.filePath, fullPage: options.fullPageImage, captureBeyondViewport: options.fullPageImage || false });
+      return page.screenshot({ path: options.filePath, fullPage: options.fullPageImage, captureBeyondViewport: false });
     }, 'screenshot');
 
     if (options.scaleImage && !isPDF) {


### PR DESCRIPTION
This PR fixes blank page screenshot bug.

Puppeter resizes the viewport when taking a screenshot. See details [here](https://stackoverflow.com/questions/68059664/puppeteer-page-screenshot-resizes-viewport)

After [this PR](https://github.com/grafana/grafana/pull/90755) in scenes, when taking the screenshot `isMobile` is true for a while (randomly). That makes the dashboard re-render and the screenshot ends up being a blank page, showing only the NavToolbar.
[Issue thread](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1722456214228329).

With `captureBeyondViewport` as false, it works as expected, because we set the viewport based on [panels container `scrollHeight`](https://github.com/grafana/grafana-image-renderer/blob/master/src/browser/browser.ts#L211) [here](https://github.com/grafana/grafana-image-renderer/blob/master/src/browser/browser.ts#L371)


| Before  | After |
| ------------- | ------------- |
| <img width="995" alt="image" src="https://github.com/user-attachments/assets/c27e48d7-9c36-4c09-880c-b9b6bf09fe5e"> | <img width="995" alt="image" src="https://github.com/user-attachments/assets/fdb65070-16fb-4aef-8f5d-cdb64df5e455"> |


