### PR TITLE
Chore: Update ci token path

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -496,7 +496,7 @@ name: gcr
 ---
 get:
   name: github_token
-  path: infra/data/ci/drone-plugins
+  path: ci/data/repo/grafana/grafana-image-renderer/github_actions
 kind: secret
 name: github_token
 ---

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -17,7 +17,7 @@ def vault_secret(name, path, key):
 def secrets():
     return [
         vault_secret(gcr_pull_secret, 'secret/data/common/gcr', '.dockerconfigjson'),
-        vault_secret('github_token', 'infra/data/ci/drone-plugins', 'github_token'),
+        vault_secret('github_token', 'ci/data/repo/grafana/grafana-image-renderer/github_actions', 'github_token')
         vault_secret('gcom_publish_token', 'infra/data/ci/drone-plugins', 'gcom_publish_token'),
         vault_secret('grafana_api_key', 'infra/data/ci/drone-plugins', 'grafana_api_key'),
         vault_secret('srcclr_api_token', 'infra/data/ci/drone-plugins', 'srcclr_api_token'),


### PR DESCRIPTION
Update the path to manage inside the team if needed. This will soon be deprecated in favor of the GitHub App.
