### PR TITLE
Support cancel rendering on client cancellation

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -277,16 +277,6 @@ export class Browser {
         return browser!.newPage();
       });
 
-      signal.addEventListener('abort', () => {
-        if (page) {
-          this.removePageListeners(page);
-          page.close();
-        }
-        if (browser) {
-          browser.close();
-        }
-      });
-
       this.addPageListeners(page);
 
       return await this.takeScreenshot(page, options, signal);
@@ -437,16 +427,6 @@ export class Browser {
       const launcherOptions = this.getLauncherOptions(options);
       browser = await puppeteer.launch(launcherOptions);
       page = await browser.newPage();
-
-      signal.addEventListener('abort', () => {
-        if (page) {
-          this.removePageListeners(page);
-          page.close();
-        }
-        if (browser) {
-          browser.close();
-        }
-      });
 
       this.addPageListeners(page);
 

--- a/src/browser/clustered.ts
+++ b/src/browser/clustered.ts
@@ -14,6 +14,7 @@ interface ClusterOptions {
   groupId?: string;
   options: RenderOptions | ImageRenderOptions;
   renderType: RenderType;
+  signal: AbortSignal;
 }
 
 type ClusterResponse = RenderResponse | RenderCSVResponse;
@@ -71,19 +72,26 @@ export class ClusteredBrowser extends Browser {
   async start(): Promise<void> {
     this.cluster = await this.createCluster();
     await this.cluster.task(async ({ page, data }) => {
-      if (data.options.timezone) {
+      const { options, renderType, signal } = data;
+      if (options.timezone) {
         // set timezone
-        await page.emulateTimezone(data.options.timezone);
+        await page.emulateTimezone(options.timezone);
       }
 
       try {
+        signal.addEventListener('abort', () => {
+          if (page) {
+            this.removePageListeners(page);
+          }
+        });
+
         this.addPageListeners(page);
-        switch (data.renderType) {
+        switch (renderType) {
           case RenderType.CSV:
-            return await this.exportCSV(page, data.options);
+            return await this.exportCSV(page, options, signal);
           case RenderType.PNG:
           default:
-            return await this.takeScreenshot(page, data.options as ImageRenderOptions);
+            return await this.takeScreenshot(page, options as ImageRenderOptions, signal);
         }
       } finally {
         this.removePageListeners(page);
@@ -99,13 +107,13 @@ export class ClusteredBrowser extends Browser {
     return undefined;
   };
 
-  async render(options: ImageRenderOptions): Promise<RenderResponse> {
+  async render(options: ImageRenderOptions, signal: AbortSignal): Promise<RenderResponse> {
     this.validateImageOptions(options);
-    return this.cluster.execute({ groupId: this.getGroupId(options), options, renderType: RenderType.PNG });
+    return this.cluster.execute({ groupId: this.getGroupId(options), options, renderType: RenderType.PNG, signal });
   }
 
-  async renderCSV(options: RenderOptions): Promise<RenderCSVResponse> {
+  async renderCSV(options: RenderOptions, signal: AbortSignal): Promise<RenderCSVResponse> {
     this.validateRenderOptions(options);
-    return this.cluster.execute({ groupId: this.getGroupId(options), options, renderType: RenderType.CSV });
+    return this.cluster.execute({ groupId: this.getGroupId(options), options, renderType: RenderType.CSV, signal });
   }
 }

--- a/src/browser/error.ts
+++ b/src/browser/error.ts
@@ -1,0 +1,6 @@
+export class TimeoutError extends Error {
+  constructor(step) {
+    super('Timeout error while performing step: ' + step);
+    this.name = 'TimeoutError';
+  }
+}

--- a/src/browser/error.ts
+++ b/src/browser/error.ts
@@ -1,4 +1,4 @@
-export class TimeoutError extends Error {
+export class StepTimeoutError extends Error {
   constructor(step) {
     super('Timeout error while performing step: ' + step);
     this.name = 'TimeoutError';

--- a/src/browser/reusable.ts
+++ b/src/browser/reusable.ts
@@ -21,11 +21,11 @@ export class ReusableBrowser extends Browser {
     let page: puppeteer.Page | undefined;
 
     try {
-      page = await this.withTimingMetrics<puppeteer.Page>(async () => {
+      page = await this.withTimingMetrics<puppeteer.Page>('newPage', async () => {
         this.validateImageOptions(options);
         context = await this.browser.createBrowserContext();
         return context.newPage();
-      }, 'newPage');
+      });
 
       if (options.timezone) {
         // set timezone

--- a/src/browser/reusable.ts
+++ b/src/browser/reusable.ts
@@ -16,7 +16,7 @@ export class ReusableBrowser extends Browser {
     this.browser = await puppeteer.launch(launcherOptions);
   }
 
-  async render(options: ImageRenderOptions): Promise<RenderResponse> {
+  async render(options: ImageRenderOptions, signal: AbortSignal): Promise<RenderResponse> {
     let context: puppeteer.BrowserContext | undefined;
     let page: puppeteer.Page | undefined;
 
@@ -32,9 +32,19 @@ export class ReusableBrowser extends Browser {
         await page.emulateTimezone(options.timezone);
       }
 
+      signal.addEventListener('abort', () => {
+        if (page) {
+          this.removePageListeners(page);
+          page.close();
+        }
+        if (context) {
+          context.close();
+        }
+      });
+
       this.addPageListeners(page);
 
-      return await this.takeScreenshot(page, options);
+      return await this.takeScreenshot(page, options, signal);
     } finally {
       if (page) {
         this.removePageListeners(page);
@@ -46,7 +56,7 @@ export class ReusableBrowser extends Browser {
     }
   }
 
-  async renderCSV(options: RenderOptions): Promise<RenderCSVResponse> {
+  async renderCSV(options: RenderOptions, signal: AbortSignal): Promise<RenderCSVResponse> {
     let context: puppeteer.BrowserContext | undefined;
     let page: puppeteer.Page | undefined;
 
@@ -60,9 +70,19 @@ export class ReusableBrowser extends Browser {
         await page.emulateTimezone(options.timezone);
       }
 
+      signal.addEventListener('abort', () => {
+        if (page) {
+          this.removePageListeners(page);
+          page.close();
+        }
+        if (context) {
+          context.close();
+        }
+      });
+
       this.addPageListeners(page);
 
-      return await this.exportCSV(page, options);
+      return await this.exportCSV(page, options, signal);
     } finally {
       if (page) {
         this.removePageListeners(page);

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -53,7 +53,7 @@ const pluginV2ProtoDescriptor = grpc.loadPackageDefinition(pluginV2PackageDef);
 const sanitizerProtoDescriptor = grpc.loadPackageDefinition(sanitizerPackageDef);
 
 export class RenderGRPCPluginV2 implements GrpcPlugin {
-  constructor(private config: PluginConfig, private log: Logger) { }
+  constructor(private config: PluginConfig, private log: Logger) {}
 
   async grpcServer(server: grpc.Server) {
     const metrics = setupMetrics();
@@ -92,7 +92,7 @@ export class RenderGRPCPluginV2 implements GrpcPlugin {
 class PluginGRPCServer {
   private browserVersion: string | undefined;
 
-  constructor(private browser: Browser, private log: Logger, private sanitizer: Sanitizer, private securityCfg: SecurityConfig) { }
+  constructor(private browser: Browser, private log: Logger, private sanitizer: Sanitizer, private securityCfg: SecurityConfig) {}
 
   async start(browserVersion?: string) {
     this.browserVersion = browserVersion;
@@ -100,6 +100,7 @@ class PluginGRPCServer {
   }
 
   async render(call: grpc.ServerUnaryCall<RenderRequest, any>, callback: grpc.sendUnaryData<RenderResponse>) {
+    const { signal } = new AbortController();
     const req = call.request;
     const headers: HTTPHeaders = {};
 
@@ -141,7 +142,7 @@ class PluginGRPCServer {
     this.log.debug('Render request received', 'url', options.url);
     let errStr = '';
     try {
-      await this.browser.render(options);
+      await this.browser.render(options, signal);
     } catch (err) {
       this.log.error('Render request failed', 'url', options.url, 'error', err.toString());
       errStr = err.toString();
@@ -150,6 +151,8 @@ class PluginGRPCServer {
   }
 
   async renderCsv(call: grpc.ServerUnaryCall<RenderCSVRequest, any>, callback: grpc.sendUnaryData<RenderCSVResponse>) {
+    const { signal } = new AbortController();
+
     const req = call.request;
     const headers: HTTPHeaders = {};
 
@@ -188,7 +191,7 @@ class PluginGRPCServer {
     let errStr = '';
     let fileName = '';
     try {
-      const result = await this.browser.renderCSV(options);
+      const result = await this.browser.renderCSV(options, signal);
       fileName = result.fileName || '';
     } catch (err) {
       this.log.error('Render request failed', 'url', options.url, 'error', err.toString());

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -100,7 +100,9 @@ class PluginGRPCServer {
   }
 
   async render(call: grpc.ServerUnaryCall<RenderRequest, any>, callback: grpc.sendUnaryData<RenderResponse>) {
-    const { signal } = new AbortController();
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
     const req = call.request;
     const headers: HTTPHeaders = {};
 
@@ -140,7 +142,12 @@ class PluginGRPCServer {
     };
 
     this.log.debug('Render request received', 'url', options.url);
+    call.on('cancelled', (err) => {
+      this.log.debug('Connection closed', 'url', options.url, 'error', err);
+      abortController.abort();
+    });
     let errStr = '';
+
     try {
       await this.browser.render(options, signal);
     } catch (err) {
@@ -151,7 +158,8 @@ class PluginGRPCServer {
   }
 
   async renderCsv(call: grpc.ServerUnaryCall<RenderCSVRequest, any>, callback: grpc.sendUnaryData<RenderCSVResponse>) {
-    const { signal } = new AbortController();
+    const abortController = new AbortController();
+    const { signal } = abortController;
 
     const req = call.request;
     const headers: HTTPHeaders = {};
@@ -188,6 +196,11 @@ class PluginGRPCServer {
     };
 
     this.log.debug('Render request received', 'url', options.url);
+    call.on('cancelled', (err) => {
+      this.log.debug('Connection closed', 'url', options.url, 'error', err);
+      abortController.abort();
+    });
+
     let errStr = '';
     let fileName = '';
     try {

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -136,7 +136,7 @@ export class HttpServer {
   createServer() {
     const { protocol, host, port } = this.config.service;
     if (protocol === 'https') {
-      const { certFile, certKey, minTLSVersion } = this.config.service
+      const { certFile, certKey, minTLSVersion } = this.config.service;
       if (!certFile || !certKey) {
         throw new Error('No cert file or cert key provided, cannot start HTTPS server');
       }
@@ -148,16 +148,16 @@ export class HttpServer {
       const options = {
         cert: fs.readFileSync(certFile),
         key: fs.readFileSync(certKey),
-      
+
         maxVersion: 'TLSv1.3' as SecureVersion,
         minVersion: (minTLSVersion || 'TLSv1.2') as SecureVersion,
-      }
-      
-      this.server = https.createServer(options, this.app)
+      };
+
+      this.server = https.createServer(options, this.app);
     } else {
-      this.server = http.createServer(this.app)
-    } 
-    
+      this.server = http.createServer(this.app);
+    }
+
     if (host) {
       this.server.listen(port, host, () => {
         const info = this.server.address() as net.AddressInfo;
@@ -176,6 +176,9 @@ export class HttpServer {
   }
 
   render = async (req: express.Request<any, any, any, ImageRenderOptions, any>, res: express.Response, next: express.NextFunction) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
     if (!req.query.url) {
       throw boom.badRequest('Missing url parameter');
     }
@@ -203,22 +206,28 @@ export class HttpServer {
     this.log.debug('Render request received', 'url', options.url);
     req.on('close', (err) => {
       this.log.debug('Connection closed', 'url', options.url, 'error', err);
+      abortController.abort();
     });
 
-    const result = await this.browser.render(options);
+    try {
+      const result = await this.browser.render(options, signal);
 
-    res.sendFile(result.filePath, (err) => {
-      if (err) {
-        next(err);
-      } else {
-        try {
-          this.log.debug('Deleting temporary file', 'file', result.filePath);
-          fs.unlinkSync(result.filePath);
-        } catch (e) {
-          this.log.error('Failed to delete temporary file', 'file', result.filePath);
+      res.sendFile(result.filePath, (err) => {
+        if (err) {
+          next(err);
+        } else {
+          try {
+            this.log.debug('Deleting temporary file', 'file', result.filePath);
+            fs.unlinkSync(result.filePath);
+          } catch (e) {
+            this.log.error('Failed to delete temporary file', 'file', result.filePath);
+          }
         }
-      }
-    });
+      });
+    } catch (e) {
+      this.log.error('Render failed', 'url', options.url, 'error', e.stack);
+      return res.status(500).json({ error: e.message });
+    }
   };
 
   sanitize = async (req: express.Request<any, { error: string }>, res: express.Response<{ error: string }>) => {
@@ -260,6 +269,8 @@ export class HttpServer {
   };
 
   renderCSV = async (req: express.Request<any, any, any, RenderOptions, any>, res: express.Response, next: express.NextFunction) => {
+    const { abort, signal } = new AbortController();
+
     if (!req.query.url) {
       throw boom.badRequest('Missing url parameter');
     }
@@ -284,8 +295,9 @@ export class HttpServer {
     this.log.debug('Render request received', 'url', options.url);
     req.on('close', (err) => {
       this.log.debug('Connection closed', 'url', options.url, 'error', err);
+      abort();
     });
-    const result = await this.browser.renderCSV(options);
+    const result = await this.browser.renderCSV(options, signal);
 
     if (result.fileName) {
       res.setHeader('Content-Disposition', contentDisposition(result.fileName));
@@ -298,13 +310,13 @@ export class HttpServer {
           this.log.debug('Deleting temporary file', 'file', result.filePath);
           fs.unlink(result.filePath, (err) => {
             if (err) {
-              throw err
+              throw err;
             }
 
             if (!options.filePath) {
               fs.rmdir(path.dirname(result.filePath), () => {});
             }
-          })
+          });
         } catch (e) {
           this.log.error('Failed to delete temporary file', 'file', result.filePath, 'error', e.message);
         }


### PR DESCRIPTION
Currently when client cancels the requests, the rendering request continues to run until it ends. 

This PR fixes that by stopping the rendering process.

It has two main benefits:
- Improve performance when the image renderer is receiving a lot of requests from Grafana, especially when it comes from the alerting feature. In the alerting feature, image renderer requests are stacked when they exceed the concurrent request limit, so they can be made after a few seconds, be cancelled right after that because they exceed the timeout and still use the image renderer CPU and memory to render the image.
- Remove logs `Failed to get render key from cache`. This is displayed when the image renderer tries to access Grafana after the request is cancelled because the render key has been deleted but this makes it more complicated to investigate real issues.

Fixes https://github.com/grafana/grafana-image-renderer/issues/186