### PR TITLE
Metrics: Exclude /render/version from duration and inflight metrics

### DIFF
--- a/src/service/metrics.ts
+++ b/src/service/metrics.ts
@@ -15,7 +15,10 @@ export const setupHttpServerMetrics = (app: express.Express, config: MetricsConf
     config.requestDurationBuckets.join(',')
   );
 
-  const excludeRegExp = /^((?!(render)).)*$/;
+  // Exclude all non-rendering endpoints:
+  //   - endpoints that do not include render
+  //   - /render/version
+  const excludeRegExp = /^(((?!(render)).)*|.*version.*)$/;
 
   const opts = {
     httpDurationMetricName: 'grafana_image_renderer_service_http_request_duration_seconds',


### PR DESCRIPTION
Currently, the endpoint /render/version is included in the following metrics:
- grafana_image_renderer_service_http_request_duration_seconds
- grafana_image_renderer_http_request_in_flight

This doesn't really make sense as we want to track the duration of rendering requests. Plus, they don't have at all the same duration (a rendering requests takes several seconds to be completed while /render/version takes a hundred milliseconds). 