### PR TITLE
Release 3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,89 +1,116 @@
+## 3.12.1 (2025-02-10)
+
+- Chore: upgrade deps [#593](https://github.com/grafana/grafana-image-renderer/pull/593), [AgnesToulet](https://github.com/AgnesToulet)
+- Logs: Redirect log in response [#589](https://github.com/grafana/grafana-image-renderer/pull/589), [juanicabanas](https://github.com/juanicabanas)
+- Metrics: Exclude /render/version from duration and inflight metrics [#591](https://github.com/grafana/grafana-image-renderer/pull/591), [AgnesToulet](https://github.com/AgnesToulet)
+
 ## 3.12.0 (2025-01-14)
+
 - Support cancel rendering requests on client cancellation [#588](https://github.com/grafana/grafana-image-renderer/pull/588), [AgnesToulet](https://github.com/AgnesToulet)
 - Chore: Add ENV variables for temp folders in Docker [#583](https://github.com/grafana/grafana-image-renderer/pull/583), [evictorero](https://github.com/evictorero)
 - Add image source label to dockerfiles [#573](https://github.com/grafana/grafana-image-renderer/pull/573), [wuast94](https://github.com/wuast94)
 
 ## 3.11.6 (2024-10-17)
+
 - Chore: Upgrade express from 4.21.0 to 4.21.1 [#577](https://github.com/grafana/grafana-image-renderer/pull/577), [AgnesToulet](https://github.com/AgnesToulet)
 - Chore: Don't install dev packages in Docker image [#575](https://github.com/grafana/grafana-image-renderer/pull/575), [McTonderski](https://github.com/McTonderski), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump dompurify from 2.4.7 to 2.5.4 [#574](https://github.com/grafana/grafana-image-renderer/pull/574), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.11.5 (2024-09-12)
+
 - Bump express to 4.21.0 [#567](https://github.com/grafana/grafana-image-renderer/pull/567), [evictorero](https://github.com/evictorero)
 - Bump micromatch from 4.0.7 to 4.0.8 [#561](https://github.com/grafana/grafana-image-renderer/pull/561), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.11.4 (2024-08-30)
+
 - Puppeteer: Upgrade to v22 [#556](https://github.com/grafana/grafana-image-renderer/pull/556), [evictorero](https://github.com/evictorero)
 
 ## 3.11.3 (2024-08-13)
+
 - Full page image: Fix blank page screenshot when scenes is turned on [#554](https://github.com/grafana/grafana-image-renderer/pull/554), [juanicabanas](https://github.com/juanicabanas)
 
 ## 3.11.2 (2024-08-08)
+
 - Properly support dashboards where the scrollable element is the document [#552](https://github.com/grafana/grafana-image-renderer/pull/552), [ashharrison90](https://github.com/ashharrison90)
 
 ## 3.11.1 (2024-07-15)
+
 - Full page image: Fix wait condition for dashboard with rows [#542](https://github.com/grafana/grafana-image-renderer/pull/542), [AgnesToulet](https://github.com/AgnesToulet)
 - Chore: Upgrade Jimp deps [541](https://github.com/grafana/grafana-image-renderer/pull/541), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.11.0 (2024-06-13)
+
 - Chore: Upgrade chokidar and jest dependencies [#532](https://github.com/grafana/grafana-image-renderer/pull/532), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump @grpc/grpc-js from 1.8.20 to 1.8.22 [#531](https://github.com/grafana/grafana-image-renderer/pull/531), [dependabot[bot]](https://github.com/apps/dependabot)
 - Server: Fix CSV deletion [#530](https://github.com/grafana/grafana-image-renderer/pull/530), [AgnesToulet](https://github.com/AgnesToulet)
 - Server: Support HTTPS configuration [#527](https://github.com/grafana/grafana-image-renderer/pull/527), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.10.5 (2024-05-23)
+
 - Packages: Release Alpine package without Chromium [#525](https://github.com/grafana/grafana-image-renderer/pull/525), [AgnesToulet](https://github.com/AgnesToulet)
 - Full page image: Fix scrolling with the new native scroll [#524](https://github.com/grafana/grafana-image-renderer/pull/524), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.10.4 (2024-05-06)
+
 - Chore: Remove unused dependencies [#517](https://github.com/grafana/grafana-image-renderer/pull/517), [evictorero](https://github.com/evictorero)
 
 ## 3.10.3 (2024-04-16)
+
 - Bump protobufjs from 7.2.4 to 7.2.6 [#515](https://github.com/grafana/grafana-image-renderer/pull/515), [dependabot[bot]](https://github.com/apps/dependabot)
- 
+
 ## 3.10.2 (2024-04-08)
+
 - Bump express from 4.18.2 to 4.19.2 [#510](https://github.com/grafana/grafana-image-renderer/pull/510), [dependabot[bot]](https://github.com/apps/dependabot)
 - Bump follow-redirects from 1.15.5 to 1.15.6 [#508](https://github.com/grafana/grafana-image-renderer/pull/508), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.10.1 (2024-03-07)
+
 - Bump axios from 1.6.0 to 1.6.7 [#503](https://github.com/grafana/grafana-image-renderer/pull/503), [evictorero](https://github.com/evictorero)
 - Bump ip from 1.1.8 to 1.1.9 [#500](https://github.com/grafana/grafana-image-renderer/pull/500), [dependabot[bot]](https://github.com/apps/dependabot)
 - PDF: Fix resolution when zooming in [#502](https://github.com/grafana/grafana-image-renderer/pull/502), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.10.0 (2024-02-20)
+
 - WaitingForPanels: Change waiting logic for Scenes [#496](https://github.com/grafana/grafana-image-renderer/pull/496), [torkelo](https://github.com/torkelo)
 - Experimental: Support PDF rendering [#487](https://github.com/grafana/grafana-image-renderer/pull/487), [ryantxu](https://github.com/ryantxu)
 
 ## 3.9.1 (2024-01-29)
+
 - Chore: Upgrade jimp and node [#492](https://github.com/grafana/grafana-image-renderer/pull/492), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump follow-redirects from 1.15.3 to 1.15.4 [#489](https://github.com/grafana/grafana-image-renderer/pull/489), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.9.0 (2023-12-04)
+
 - Config: Improve consistency between plugin and server mode [#477](https://github.com/grafana/grafana-image-renderer/pull/477), [AgnesToulet](https://github.com/AgnesToulet)
 - Chore: Bump axios from 0.27.2 to 1.6.0 [#480](https://github.com/grafana/grafana-image-renderer/pull/480), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.8.4 (2023-10-17)
+
 - Bump xml2js to 0.6.2 [#473](https://github.com/grafana/grafana-image-renderer/pull/473), [AgnesToulet](https://github.com/AgnesToulet)
 - Browser: Fix panel rendered waiting condition [#472](https://github.com/grafana/grafana-image-renderer/pull/472), [AgnesToulet](https://github.com/AgnesToulet)
 - Docker: Add build for arm64 [#468](https://github.com/grafana/grafana-image-renderer/pull/468), [michbeck100](https://github.com/michbeck100)
 - Fix timezone config always overwritten [#463](https://github.com/grafana/grafana-image-renderer/pull/463), [zhichli](https://github.com/zhichli)
 
 ## 3.8.3 (2023-09-29)
+
 - Chore: Upgrade to Node 18 [#448](https://github.com/grafana/grafana-image-renderer/pull/448), [Clarity-89](https://github.com/Clarity-89)
 
 ## 3.8.2 (2023-09-21)
+
 - Browser: Revert to old headless mode to fix usage with Kubernetes [#459](https://github.com/grafana/grafana-image-renderer/pull/459), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.8.1 (2023-09-18)
-- Fix check condition to avoid timeouts in invalid panels [#299](https://github.com/grafana/grafana-image-renderer/pull/299), [spinillos](https://github.com/spinillos) 
+
+- Fix check condition to avoid timeouts in invalid panels [#299](https://github.com/grafana/grafana-image-renderer/pull/299), [spinillos](https://github.com/spinillos)
 - Plugin: fix Chrome path [#451](https://github.com/grafana/grafana-image-renderer/pull/451), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.8.0 (2023-08-22)
-- Puppeteer: upgrade to v21 [#433](https://github.com/grafana/grafana-image-renderer/pull/433), [Clarity-89](https://github.com/Clarity-89) 
+
+- Puppeteer: upgrade to v21 [#433](https://github.com/grafana/grafana-image-renderer/pull/433), [Clarity-89](https://github.com/Clarity-89)
 - Fix fullpage waitFor conditions [#446](https://github.com/grafana/grafana-image-renderer/pull/446), [AgnesToulet](https://github.com/AgnesToulet)
 
-
 ## 3.7.2 (2023-07-27)
+
 - Chore: update all dependencies [#443](https://github.com/grafana/grafana-image-renderer/pull/443), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump protobufjs from 7.1.1 to 7.2.4 [#438](https://github.com/grafana/grafana-image-renderer/pull/438), [dependabot[bot]](https://github.com/apps/dependabot)
 - Bump tough-cookie from 4.1.2 to 4.1.3 [#439](https://github.com/grafana/grafana-image-renderer/pull/439), [dependabot[bot]](https://github.com/apps/dependabot)
@@ -91,10 +118,12 @@
 - Bump word-wrap from 1.2.3 to 1.2.4 [#441](https://github.com/grafana/grafana-image-renderer/pull/441), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.7.1 (2023-05-15)
+
 - Docker: remove alpine edge repo [#413](https://github.com/grafana/grafana-image-renderer/pull/413), [sozercan](https://github.com/sozercan)
 - Bump yaml from 2.1.1 to 2.2.2 [#421](https://github.com/grafana/grafana-image-renderer/pull/421), [dependabot[bot]](https://github.com/apps/dependabot)
 
 ## 3.7.0 (2023-04-17)
+
 - Security: can set array of auth tokens [#417](https://github.com/grafana/grafana-image-renderer/pull/417), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump pkg from 5.8.0 to 5.8.1 [#415](https://github.com/grafana/grafana-image-renderer/pull/415), [AgnesToulet](https://github.com/AgnesToulet)
 - Bump jimp from 0.16.1 to 0.16.13 [#406](https://github.com/grafana/grafana-image-renderer/pull/406), [AgnesToulet](https://github.com/AgnesToulet)
@@ -113,7 +142,7 @@
 
 - Log errors related to JSHandle@object as debug [#376](https://github.com/grafana/grafana-image-renderer/pull/376), [spinillos](https://github.com/spinillos)
 - Chore: Update Puppeteer deprecated functions [#375](https://github.com/grafana/grafana-image-renderer/pull/375), [spinillos](https://github.com/spinillos)
-- Fix: Update _client with _client() to avoid to fail when creating a CSV [#372](https://github.com/grafana/grafana-image-renderer/pull/372), [spinillos](https://github.com/spinillos)
+- Fix: Update \_client with \_client() to avoid to fail when creating a CSV [#372](https://github.com/grafana/grafana-image-renderer/pull/372), [spinillos](https://github.com/spinillos)
 - Chore: Update all dependencies [#369](https://github.com/grafana/grafana-image-renderer/pull/369), [DanCech](https://github.com/DanCech)
 
 ## 3.6.1 (2022-08-30)
@@ -129,7 +158,7 @@
 ## 3.5.0 (2022-07-18)
 
 - Added File Sanitization API with [DOMPurify](https://github.com/cure53/DOMPurify) as the backend. [#349](https://github.com/grafana/grafana-image-renderer/pull/349), [ArturWierzbicki](https://github.com/ArturWierzbicki)
-- Security: upgrade dependencies [#356](https://github.com/grafana/grafana-image-renderer/pull/356), [#348](https://github.com/grafana/grafana-image-renderer/pull/348), [#347](https://github.com/grafana/grafana-image-renderer/pull/347),  [AgnesToulet](https://github.com/AgnesToulet)
+- Security: upgrade dependencies [#356](https://github.com/grafana/grafana-image-renderer/pull/356), [#348](https://github.com/grafana/grafana-image-renderer/pull/348), [#347](https://github.com/grafana/grafana-image-renderer/pull/347), [AgnesToulet](https://github.com/AgnesToulet)
 
 ## 3.4.2 (2022-03-23)
 

--- a/plugin.json
+++ b/plugin.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "3.12.0",
-    "updated": "2025-01-14"
+    "version": "3.12.1",
+    "updated": "2025-02-10"
   },
   "dependencies": {
     "grafanaDependency": ">=8.3.11"


### PR DESCRIPTION
## 3.12.1 (2025-02-10)

- Chore: upgrade deps [#593](https://github.com/grafana/grafana-image-renderer/pull/593), [AgnesToulet](https://github.com/AgnesToulet)
- Logs: Redirect log in response [#589](https://github.com/grafana/grafana-image-renderer/pull/589), [juanicabanas](https://github.com/juanicabanas)
- Metrics: Exclude /render/version from duration and inflight metrics [#591](https://github.com/grafana/grafana-image-renderer/pull/591), [AgnesToulet](https://github.com/AgnesToulet)