### PR TITLE
Add tracing to plugin mode and improve config management

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,10 +20,6 @@
       }
     },
 
-    "tracing": {
-      "enabled": false
-    },
-
     "security": {
       "authToken": "-"
     }
@@ -55,6 +51,10 @@
 
     "verboseLogging": false,
     "dumpio": false,
-    "timingMetrics": false
+    "timingMetrics": false,
+
+    "tracing": {
+      "url": ""
+    }
   }
 }

--- a/dev.json
+++ b/dev.json
@@ -15,10 +15,6 @@
         "json": false,
         "colorize": true
       }
-    },
-    
-    "tracing": {
-      "enabled": true
     }
   },
   "rendering": {
@@ -54,6 +50,11 @@
 
     "verboseLogging": true,
     "dumpio": false,
-    "timingMetrics": true
+    "timingMetrics": true,
+
+    "tracing": {
+      "enabled": true,
+      "url": "http://localhost:4318/v1/traces"
+    }
   }
 }

--- a/dev.json
+++ b/dev.json
@@ -53,8 +53,7 @@
     "timingMetrics": true,
 
     "tracing": {
-      "enabled": true,
-      "url": "http://localhost:4318/v1/traces"
+      "url": ""
     }
   }
 }

--- a/devenv/docker/custom-config/config.json
+++ b/devenv/docker/custom-config/config.json
@@ -15,10 +15,6 @@
         "json": true,
         "colorize": false
       }
-    },
-        
-    "tracing": {
-      "enabled": false
     }
   },
   "rendering": {
@@ -45,6 +41,10 @@
     },
 
     "verboseLogging": false,
-    "dumpio": false
+    "dumpio": false,
+
+    "tracing": {
+      "url": ""
+    }
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ async function main() {
     const config = getConfig() as PluginConfig;
     const logger = new PluginLogger();
 
-    if (config.rendering.tracing.enabled) {
+    if (config.rendering.tracing.url) {
       startTracing(logger);
     }
 
@@ -58,7 +58,7 @@ async function main() {
     const config = getConfig() as ServiceConfig;
     const logger = new ConsoleLogger(config.service.logging);
 
-    if (config.rendering.tracing.enabled) {
+    if (config.rendering.tracing.url) {
       startTracing(logger);
     }
 

--- a/src/browser/browser.test.ts
+++ b/src/browser/browser.test.ts
@@ -26,6 +26,9 @@ const renderingConfig = {
   verboseLogging: false,
   dumpio: false,
   timingMetrics: false,
+  tracing: {
+    url: '',
+  },
   emulateNetworkConditions: false,
 };
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -34,7 +34,7 @@ export class Browser {
 
   constructor(protected config: RenderingConfig, protected log: Logger, protected metrics: Metrics) {
     this.log.debug('Browser initialized', 'config', this.config);
-    if (config.tracing.enabled) {
+    if (config.tracing.url) {
       this.tracer = trace.getTracer('browser');
     }
   }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -31,10 +31,12 @@ type PuppeteerLaunchOptions = Parameters<typeof puppeteer['launch']>[0];
 
 export class Browser {
   tracer: Tracer;
-  
+
   constructor(protected config: RenderingConfig, protected log: Logger, protected metrics: Metrics) {
     this.log.debug('Browser initialized', 'config', this.config);
-    this.tracer = trace.getTracer('browser');
+    if (config.tracing.enabled) {
+      this.tracer = trace.getTracer('browser');
+    }
   }
 
   async getBrowserVersion(): Promise<string> {
@@ -266,13 +268,13 @@ export class Browser {
     let page: puppeteer.Page | undefined = undefined;
 
     try {
-      browser = await this.withTimingMetrics<puppeteer.Browser>('launch', () => {
+      browser = await this.withMonitoring<puppeteer.Browser>('launch', () => {
         this.validateImageOptions(options);
         const launcherOptions = this.getLauncherOptions(options);
         return puppeteer.launch(launcherOptions);
       });
 
-      page = await this.withTimingMetrics<puppeteer.Page>('newPage', () => {
+      page = await this.withMonitoring<puppeteer.Page>('newPage', () => {
         return browser!.newPage();
       });
 
@@ -510,7 +512,7 @@ export class Browser {
     }
 
     try {
-      const res = await this.withTimingMetrics(step, callback);
+      const res = await this.withMonitoring(step, callback);
 
       if (signal.aborted) {
         this.log.warn('Signal aborted while performing step', 'step', step, 'url', url);
@@ -532,21 +534,34 @@ export class Browser {
     }
   }
 
-  async withTimingMetrics<T>(step: string, callback: () => Promise<T>): Promise<T> {
+  async withMonitoring<T>(step: string, callback: () => Promise<T>): Promise<T> {
+    // Wrap callback with timing metrics if enabled
     if (this.config.timingMetrics) {
-      const endTimer = this.metrics.durationHistogram.startTimer({ step });
-      const res = this.tracer.startActiveSpan(step, async (span) => {
-        const cbRes = await callback();
-        span.end();
-        return cbRes;
-      });
-
-      endTimer();
-
-      return res;
-    } else {
-      return callback();
+      const originalCallback = callback;
+      callback = async () => {
+        const endTimer = this.metrics.durationHistogram.startTimer({ step });
+        try {
+          return await originalCallback();
+        } finally {
+          endTimer();
+        }
+      };
     }
+
+    // Wrap callback with tracing if enabled
+    if (this.tracer) {
+      const originalCallback = callback;
+      callback = () =>
+        this.tracer.startActiveSpan(step, async (span) => {
+          try {
+            return await originalCallback();
+          } finally {
+            span.end();
+          }
+        });
+    }
+
+    return callback();
   }
 
   addPageListeners(page: puppeteer.Page) {

--- a/src/browser/reusable.ts
+++ b/src/browser/reusable.ts
@@ -21,7 +21,7 @@ export class ReusableBrowser extends Browser {
     let page: puppeteer.Page | undefined;
 
     try {
-      page = await this.withTimingMetrics<puppeteer.Page>('newPage', async () => {
+      page = await this.withMonitoring<puppeteer.Page>('newPage', async () => {
         this.validateImageOptions(options);
         context = await this.browser.createBrowserContext();
         return context.newPage();

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as _ from 'lodash';
 import * as minimist from 'minimist';
 import { defaultServiceConfig, populateServiceConfigFromEnv, ServiceConfig } from '../service/config';
-import { defaultPluginConfig, PluginConfig, populatePluginConfigFromEnv } from '../plugin/v2/config';
+import { defaultPluginConfig, populatePluginConfigFromEnv, PluginConfig } from '../plugin/v2/config';
 
 export function getConfig(): PluginConfig | ServiceConfig {
   const argv = minimist(process.argv.slice(2));

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import * as _ from 'lodash';
+import * as minimist from 'minimist';
+import { defaultServiceConfig, populateServiceConfigFromEnv, ServiceConfig } from '../service/config';
+import { defaultPluginConfig, PluginConfig, populatePluginConfigFromEnv } from '../plugin/v2/config';
+
+export function getConfig(): PluginConfig | ServiceConfig {
+  const argv = minimist(process.argv.slice(2));
+  const env = Object.assign({}, process.env);
+  const command = argv._[0];
+
+  if (command === 'server') {
+    let config: ServiceConfig = defaultServiceConfig;
+
+    if (argv.config) {
+      try {
+        const fileConfig = readJSONFileSync(argv.config);
+        config = _.merge(config, fileConfig);
+      } catch (e) {
+        console.error('failed to read config from path', argv.config, 'error', e);
+      }
+    }
+
+    populateServiceConfigFromEnv(config, env);
+
+    return config;
+  }
+
+  const config: PluginConfig = defaultPluginConfig;
+  populatePluginConfigFromEnv(config, env);
+  return config;
+}
+
+function readJSONFileSync(filePath: string) {
+  const rawdata = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(rawdata);
+}

--- a/src/config/rendering.ts
+++ b/src/config/rendering.ts
@@ -14,7 +14,6 @@ type NetworkConditions = {
 };
 
 export interface TracesConfig {
-  enabled: boolean;
   url: string;
 }
 
@@ -68,7 +67,6 @@ export const defaultRenderingConfig: RenderingConfig = {
   dumpio: false,
   timingMetrics: false,
   tracing: {
-    enabled: false,
     url: '',
   },
 };
@@ -129,7 +127,6 @@ const envConfig: Record<Mode, Keys<RenderingConfig>> = {
     dumpio: 'GF_PLUGIN_RENDERING_DUMPIO',
     timingMetrics: 'GF_PLUGIN_RENDERING_TIMING_METRICS',
     tracing: {
-      enabled: 'GF_PLUGIN_RENDERING_TRACING_ENABLED',
       url: 'GF_PLUGIN_RENDERING_TRACING_URL',
     },
   },
@@ -220,10 +217,6 @@ export function populateRenderingConfigFromEnv(config: RenderingConfig, env: Nod
 
   if (env[envKeys.timingMetrics!]) {
     config.timingMetrics = env[envKeys.timingMetrics!] === 'true';
-  }
-
-  if (env[envKeys.tracing?.enabled!]) {
-    config.tracing.enabled = env[envKeys.tracing?.enabled!] === 'true';
   }
 
   if (env[envKeys.tracing?.url!]) {

--- a/src/config/rendering.ts
+++ b/src/config/rendering.ts
@@ -13,6 +13,11 @@ type NetworkConditions = {
   latency: number;
 };
 
+export interface TracesConfig {
+  enabled: boolean;
+  url: string;
+}
+
 export interface RenderingConfig {
   chromeBin?: string;
   args: string[];
@@ -34,6 +39,7 @@ export interface RenderingConfig {
   headed?: boolean;
   networkConditions?: NetworkConditions;
   emulateNetworkConditions: boolean;
+  tracing: TracesConfig;
 }
 
 export const defaultRenderingConfig: RenderingConfig = {
@@ -61,6 +67,10 @@ export const defaultRenderingConfig: RenderingConfig = {
   verboseLogging: false,
   dumpio: false,
   timingMetrics: false,
+  tracing: {
+    enabled: false,
+    url: '',
+  },
 };
 
 export enum Mode {
@@ -118,6 +128,10 @@ const envConfig: Record<Mode, Keys<RenderingConfig>> = {
     verboseLogging: 'GF_PLUGIN_RENDERING_VERBOSE_LOGGING',
     dumpio: 'GF_PLUGIN_RENDERING_DUMPIO',
     timingMetrics: 'GF_PLUGIN_RENDERING_TIMING_METRICS',
+    tracing: {
+      enabled: 'GF_PLUGIN_RENDERING_TRACING_ENABLED',
+      url: 'GF_PLUGIN_RENDERING_TRACING_URL',
+    },
   },
 };
 
@@ -206,5 +220,13 @@ export function populateRenderingConfigFromEnv(config: RenderingConfig, env: Nod
 
   if (env[envKeys.timingMetrics!]) {
     config.timingMetrics = env[envKeys.timingMetrics!] === 'true';
+  }
+
+  if (env[envKeys.tracing?.enabled!]) {
+    config.tracing.enabled = env[envKeys.tracing?.enabled!] === 'true';
+  }
+
+  if (env[envKeys.tracing?.url!]) {
+    config.tracing.url = env[envKeys.tracing?.url!] as string;
   }
 }

--- a/src/plugin/v2/grpc_plugin.ts
+++ b/src/plugin/v2/grpc_plugin.ts
@@ -248,7 +248,7 @@ class PluginGRPCServer {
       }
     }
 
-    if (this.config.rendering.tracing.enabled) {
+    if (this.config.rendering.tracing.url) {
       const output: TraceCarrier = {};
       propagation.inject(context.active(), output);
       const { traceparent, tracestate } = output;

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -7,10 +7,6 @@ export interface MetricsConfig {
   requestDurationBuckets: number[];
 }
 
-export interface TracesConfig {
-  enabled: boolean;
-}
-
 export interface ConsoleLoggerConfig {
   level?: string;
   json: boolean;
@@ -33,7 +29,6 @@ export interface ServiceConfig {
     metrics: MetricsConfig;
     logging: LoggingConfig;
     security: SecurityConfig;
-    tracing: TracesConfig;
   };
   rendering: RenderingConfig;
 }
@@ -54,9 +49,6 @@ export const defaultServiceConfig: ServiceConfig = {
         json: true,
         colorize: false,
       },
-    },
-    tracing: {
-      enabled: false,
     },
     security: {
       authToken: '-',

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -71,7 +71,6 @@ const serviceConfig: ServiceConfig = {
     },
     timingMetrics: false,
     tracing: {
-      enabled: false,
       url: '',
     },
     emulateNetworkConditions: false,

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -47,9 +47,6 @@ const serviceConfig: ServiceConfig = {
         colorize: false,
       },
     },
-    tracing: {
-      enabled: true,
-    },
     security: {
       authToken: '-',
     },
@@ -73,6 +70,10 @@ const serviceConfig: ServiceConfig = {
       timeout: 30,
     },
     timingMetrics: false,
+    tracing: {
+      enabled: false,
+      url: '',
+    },
     emulateNetworkConditions: false,
     // Set to true to get more logs
     verboseLogging: false, // true,
@@ -98,15 +99,15 @@ function getGrafanaEndpoint(domain: string) {
 let envSettings = {
   saveDiff: false,
   updateGolden: false,
-}
+};
 
 beforeAll(() => {
   if (process.env['CI'] === 'true') {
     domain = 'grafana';
   }
-  
-  envSettings.saveDiff = process.env['SAVE_DIFF'] === 'true'
-  envSettings.updateGolden = process.env['UPDATE_GOLDEN'] === 'true'
+
+  envSettings.saveDiff = process.env['SAVE_DIFF'] === 'true';
+  envSettings.updateGolden = process.env['UPDATE_GOLDEN'] === 'true';
 
   return server.start();
 });
@@ -183,14 +184,11 @@ describe('Test /render', () => {
     expect(pixelDiff).toBeLessThan(imageDiffThreshold);
   });
 
-  
   it('should take a full dashboard screenshot', async () => {
     const url = `${getGrafanaEndpoint(domain)}/d/${allPanelsDashboardUid}?render=1&from=1699333200000&to=1699344000000&kiosk=true`;
     const response = await request(server.app)
       .get(
-        `/render?url=${encodeURIComponent(
-          url
-        )}&timeout=5&renderKey=${renderKey}&domain=${domain}&width=${imageWidth}&height=-1&deviceScaleFactor=1`
+        `/render?url=${encodeURIComponent(url)}&timeout=5&renderKey=${renderKey}&domain=${domain}&width=${imageWidth}&height=-1&deviceScaleFactor=1`
       )
       .set('X-Auth-Token', '-');
 

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -183,18 +183,6 @@ export class HttpServer {
       throw boom.badRequest('Missing url parameter');
     }
 
-    const headers: HTTPHeaders = {};
-
-    if (req.headers['Accept-Language']) {
-      headers['Accept-Language'] = (req.headers['Accept-Language'] as string[]).join(';');
-    }
-
-    // Propagate traces 
-    if (req.headers['traceparent']) {
-      headers['traceparent'] = req.headers['traceparent'] as string;
-      headers['tracestate'] = (req.headers['tracestate'] as string) ?? '';
-    }
-
     const options: ImageRenderOptions = {
       url: req.query.url,
       width: req.query.width,
@@ -206,7 +194,7 @@ export class HttpServer {
       timezone: req.query.timezone,
       encoding: req.query.encoding,
       deviceScaleFactor: req.query.deviceScaleFactor,
-      headers: headers,
+      headers: this.getHeaders(req),
     };
 
     this.log.debug('Render request received', 'url', options.url);
@@ -282,12 +270,6 @@ export class HttpServer {
       throw boom.badRequest('Missing url parameter');
     }
 
-    const headers: HTTPHeaders = {};
-
-    if (req.headers['Accept-Language']) {
-      headers['Accept-Language'] = (req.headers['Accept-Language'] as string[]).join(';');
-    }
-
     const options: RenderOptions = {
       url: req.query.url,
       filePath: req.query.filePath,
@@ -296,7 +278,7 @@ export class HttpServer {
       domain: req.query.domain,
       timezone: req.query.timezone,
       encoding: req.query.encoding,
-      headers: headers,
+      headers: this.getHeaders(req),
     };
 
     this.log.debug('Render request received', 'url', options.url);
@@ -336,4 +318,20 @@ export class HttpServer {
       return res.status(500).json({ error: e.message });
     }
   };
+
+  getHeaders(req: express.Request<any, any, any, RenderOptions, any>): HTTPHeaders {
+    const headers: HTTPHeaders = {};
+
+    if (req.headers['Accept-Language']) {
+      headers['Accept-Language'] = (req.headers['Accept-Language'] as string[]).join(';');
+    }
+
+    // Propagate traces
+    if (req.headers['traceparent']) {
+      headers['traceparent'] = req.headers['traceparent'] as string;
+      headers['tracestate'] = (req.headers['tracestate'] as string) ?? '';
+    }
+
+    return headers;
+  }
 }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -9,7 +9,7 @@ import { getConfig } from './config/config';
 
 const config = getConfig();
 let sdk;
-if (config.rendering.tracing.enabled) {
+if (config.rendering.tracing.url) {
   sdk = initTracing(config.rendering.tracing.url);
 }
 

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -3,30 +3,40 @@ import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentation
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { Resource } from '@opentelemetry/resources';
+
 import { Logger } from './logger';
+import { getConfig } from './config/config';
 
-// For troubleshooting, set the log level to DiagLogLevel.DEBUG
-// const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
-// diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+const config = getConfig();
+let sdk;
+if (config.rendering.tracing.enabled) {
+  sdk = initTracing(config.rendering.tracing.url);
+}
 
-const traceExporter = new OTLPTraceExporter({
-  url: process.env['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'],
-});
+export function initTracing(exporterURL: string) {
+  // For troubleshooting, set the log level to DiagLogLevel.DEBUG
+  // const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
+  // diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-const sdk = new NodeSDK({
-  resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'grafana-image-renderer',
-  }),
-  traceExporter,
-  instrumentations: [
-    getNodeAutoInstrumentations({
-      // only instrument fs if it is part of another trace
-      '@opentelemetry/instrumentation-fs': {
-        requireParentSpan: true,
-      },
+  const traceExporter = new OTLPTraceExporter({
+    url: exporterURL,
+  });
+
+  return new NodeSDK({
+    resource: new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: 'grafana-image-renderer',
     }),
-  ],
-});
+    traceExporter,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        // only instrument fs if it is part of another trace
+        '@opentelemetry/instrumentation-fs': {
+          requireParentSpan: true,
+        },
+      }),
+    ],
+  });
+}
 
 export function startTracing(log: Logger) {
   sdk.start();


### PR DESCRIPTION
This PR adds tracing to the plugin mode and update a few things from the original PR:
- Read the config file before initializing tracing, this allows to have the exporter URL set in the config file instead of using an env variable
- Do no intialize the `tracer` variable if tracing is disabled
- Propagate the trace context back to Grafana

**What remains:**
- [x] Add tracing to the CSV endpoint
- [x] Compare traces between the original PR and this one to ensure we didn't lose anything by reading the config file before initializing tracing
- [x] Update [Grafana upstream PR](https://github.com/grafana/grafana/pull/100559) 
- [ ] Test, test and test again (in plugin mode, in remote server mode and in Docker)

**To test the plugin on Mac:**
1. Build the plugin locally for Mac:
    1. Update your `Makefile` to set `ARCH = darwin-arm64-unknown` 
    1. Run `make build_package`
    1. The plugin will be built in the `dist` folder
2. Copy / paste the built plugin to your Grafana plugins folder and rename it to `grafana-image-renderer`
3. In your Grafana .ini file:
    1. Comment your remote renderer settings in the `[rendering]` section
    2. Add the following config to enable traces and allow running the IR plugin unsigned:
```
[plugin.grafana-image-renderer]
rendering_tracing_url = http://localhost:4318/v1/traces

[plugins]
allow_loading_unsigned_plugins = grafana-image-renderer
```