### PR TITLE
Update dompurify to 3.2.4 - fixes CVE-2025-26791

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@hapi/boom": "^10.0.0",
     "@puppeteer/browsers": "^2.3.1",
     "chokidar": "^3.5.2",
-    "dompurify": "^2.5.4",
+    "dompurify": "^3.2.4",
     "express": "^4.21.1",
     "express-prom-bundle": "^6.5.0",
     "jimp": "^0.22.12",

--- a/src/sanitizer/Sanitizer.ts
+++ b/src/sanitizer/Sanitizer.ts
@@ -45,7 +45,7 @@ const svgTags = {
 const svgFilePrefix = '<?xml version="1.0" encoding="utf-8"?>';
 
 export class Sanitizer {
-  constructor(private domPurify: DOMPurify.DOMPurifyI) {}
+  constructor(private domPurify: DOMPurify.DOMPurify) {}
 
   private sanitizeUseTagHook = (node) => {
     if (node.nodeName === 'use') {


### PR DESCRIPTION
Updated package dompurify to 3.2.4. Patched Sanitizer.ts to work with 3.2.4