### PR TITLE
Release 3.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.12.2 (2025-03-07)
+## 3.12.2 (2025-03-06)
 
 - Image Render: Support Tracing [#586](https://github.com/grafana/grafana-image-renderer/pull/586), [lucychen-grafana](https://github.com/lucychen-grafana)
 - Server: Support HTTPS configuration using env variables [#600](https://github.com/grafana/grafana-image-renderer/pull/600), [evictorero](https://github.com/evictorero)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.12.2 (2025-03-07)
+
+- Image Render: Support Tracing [#586](https://github.com/grafana/grafana-image-renderer/pull/586), [lucychen-grafana](https://github.com/lucychen-grafana)
+- Server: Support HTTPS configuration using env variables [#600](https://github.com/grafana/grafana-image-renderer/pull/600), [evictorero](https://github.com/evictorero)
+- Docs: Update run server options [#599](https://github.com/grafana/grafana-image-renderer/pull/599), [evictorero](https://github.com/evictorero)
+- Chore: Upgrade to Node 22 [#595](https://github.com/grafana/grafana-image-renderer/pull/595), [AgnesToulet](https://github.com/AgnesToulet)
+
 ## 3.12.1 (2025-02-10)
 
 - Chore: upgrade deps [#593](https://github.com/grafana/grafana-image-renderer/pull/593), [AgnesToulet](https://github.com/AgnesToulet)

--- a/plugin.json
+++ b/plugin.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "3.12.1",
-    "updated": "2025-02-10"
+    "version": "3.12.2",
+    "updated": "2025-03-06"
   },
   "dependencies": {
     "grafanaDependency": ">=8.3.11"


### PR DESCRIPTION
## 3.12.2 (2025-03-06)

- Image Render: Support Tracing [#586](https://github.com/grafana/grafana-image-renderer/pull/586), [lucychen-grafana](https://github.com/lucychen-grafana)
- Server: Support HTTPS configuration using env variables [#600](https://github.com/grafana/grafana-image-renderer/pull/600), [evictorero](https://github.com/evictorero)
- Docs: Update run server options [#599](https://github.com/grafana/grafana-image-renderer/pull/599), [evictorero](https://github.com/evictorero)
- Chore: Upgrade to Node 22 [#595](https://github.com/grafana/grafana-image-renderer/pull/595), [AgnesToulet](https://github.com/AgnesToulet)