### PR TITLE
Chore: Update dompurify to fix CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV XDG_CACHE_HOME=/tmp/.chromium
 WORKDIR /usr/src/app
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init libxslt libexpat libjxl && \
+    apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init && \
     rm -rf /tmp/*
 
 # Build stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV XDG_CACHE_HOME=/tmp/.chromium
 WORKDIR /usr/src/app
 
 RUN apk --no-cache upgrade && \
-    apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init && \
+    apk add --no-cache udev ttf-opensans unifont chromium ca-certificates dumb-init libxslt libexpat libjxl && \
     rm -rf /tmp/*
 
 # Build stage

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@hapi/boom": "^10.0.0",
     "@puppeteer/browsers": "^2.3.1",
     "chokidar": "^3.5.2",
-    "dompurify": "^2.5.4",
+    "dompurify": "^3.2.4",
     "express": "^4.21.1",
     "express-prom-bundle": "^6.5.0",
     "jimp": "^0.22.12",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@grafana/eslint-config": "^6.0.0",
-    "@types/dompurify": "2.3.4",
+    "@types/dompurify": "^3.2.0",
     "@types/express": "^4.17.14",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "20.0.0",

--- a/src/sanitizer/Sanitizer.ts
+++ b/src/sanitizer/Sanitizer.ts
@@ -45,7 +45,7 @@ const svgTags = {
 const svgFilePrefix = '<?xml version="1.0" encoding="utf-8"?>';
 
 export class Sanitizer {
-  constructor(private domPurify: DOMPurify.DOMPurifyI) {}
+  constructor(private domPurify: DOMPurify.DOMPurify) {}
 
   private sanitizeUseTagHook = (node) => {
     if (node.nodeName === 'use') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,12 +1175,12 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
   integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
 
-"@types/dompurify@2.3.4":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.3.4.tgz#94e997e30338ea24d4c8d08beca91ce4dd17a1b4"
-  integrity sha512-EXzDatIb5EspL2eb/xPGmaC8pePcTHrkDCONjeisusLFrVfl38Pjea/R0YJGu3k9ZQadSvMqW0WXPI2hEo2Ajg==
+"@types/dompurify@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.2.0.tgz#56610bf3e4250df57744d61fbd95422e07dfb840"
+  integrity sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==
   dependencies:
-    "@types/trusted-types" "*"
+    dompurify "*"
 
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.6"
@@ -1365,7 +1365,7 @@
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
 
-"@types/trusted-types@*":
+"@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -2692,10 +2692,12 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
-dompurify@^2.5.4:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
-  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
+dompurify@*, dompurify@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[CVE Dashboard](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/sources/6/version/14256?var-package=&var-cve=&var-riskLevel=$__all&var-pkg=) 

Bump dompurify 2.5.4 to 3.2.4 [CVE-2025-26791](https://avd.aquasec.com/nvd/2025/cve-2025-26791/)


libxslt [CVE-2025-24855](https://avd.aquasec.com/nvd/2025/cve-2025-24855/) [CVE-2024-55549](https://avd.aquasec.com/nvd/2024/cve-2024-55549/), libexpat [CVE-2024-8176](https://avd.aquasec.com/nvd/2024/cve-2024-8176/), and libjxl [CVE-2024-11403](https://avd.aquasec.com/nvd/2024/cve-2024-11403/) will be updated in Chromium