### PR TITLE
Docker: Remove unused NPM files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,15 @@ WORKDIR /usr/src/app
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache udev ttf-opensans unifont chromium chromium-swiftshader ca-certificates dumb-init && \
-    rm -rf /tmp/*
+    # Remove NPM-related files and directories
+    rm -rf /usr/local/lib/node_modules/npm && \
+    rm -rf /usr/local/bin/npm && \
+    rm -rf /usr/local/bin/npx && \
+    rm -rf /root/.npm && \
+    rm -rf /root/.node-gyp && \
+    # Clean up
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/*
 
 # Build stage
 FROM base AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN apk --no-cache upgrade && \
     rm -rf /root/.npm && \
     rm -rf /root/.node-gyp && \
     # Clean up
-    rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/*
+    rm -rf /tmp/*
 
 # Build stage
 FROM base AS build


### PR DESCRIPTION
This PR removes the NPM-related files from the Node base image we are using as we are using Yarn instead of NPM. This is easier than using another base image as it seems like all the Alpine images are using NPM. 

This will prevent NPM-related CVEs to be in our Docker image while we are not even using them.

Fixes https://github.com/grafana/grafana-image-renderer/issues/425