### PR TITLE
Server: Add rate limiter

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,7 +28,7 @@
       "enabled": false,
       "redisHost": null,
       "redisPort": null,
-      "limitRps": 100
+      "requestsPerMinute": 100
     }
   },
   "rendering": {

--- a/default.json
+++ b/default.json
@@ -28,7 +28,7 @@
       "enabled": false,
       "redisHost": null,
       "redisPort": null,
-      "requestsPerMinute": 100
+      "requestsPerSecond": 5
     }
   },
   "rendering": {

--- a/default.json
+++ b/default.json
@@ -22,6 +22,13 @@
 
     "security": {
       "authToken": "-"
+    },
+
+    "rateLimiter": {
+      "enabled": false,
+      "redisHost": null,
+      "redisPort": null,
+      "limitRps": 100
     }
   },
   "rendering": {

--- a/dev.json
+++ b/dev.json
@@ -19,7 +19,7 @@
 
     "rateLimiter": {
       "enabled": false,
-      "requestsPerMinute": 5
+      "requestsPerSecond": 5
     }
   },
   "rendering": {

--- a/dev.json
+++ b/dev.json
@@ -21,7 +21,7 @@
       "enabled": true,
       "redisHost": null,
       "redisPort": null,
-      "limitRps": 100
+      "requestsPerMinute": 5
     }
   },
   "rendering": {

--- a/dev.json
+++ b/dev.json
@@ -15,6 +15,13 @@
         "json": false,
         "colorize": true
       }
+    },
+
+    "rateLimiter": {
+      "enabled": true,
+      "redisHost": null,
+      "redisPort": null,
+      "limitRps": 100
     }
   },
   "rendering": {

--- a/dev.json
+++ b/dev.json
@@ -18,9 +18,7 @@
     },
 
     "rateLimiter": {
-      "enabled": true,
-      "redisHost": null,
-      "redisPort": null,
+      "enabled": false,
       "requestsPerMinute": 5
     }
   },

--- a/devenv/docker/ratelimiter/config.json
+++ b/devenv/docker/ratelimiter/config.json
@@ -1,0 +1,56 @@
+{
+  "service": {
+    "host": null,
+    "port": 8081,
+
+    "metrics": {
+      "enabled": true,
+      "collectDefaultMetrics": true,
+      "requestDurationBuckets": [1, 5, 7, 9, 11, 13, 15, 20, 30]
+    },
+
+    "logging": {
+      "level": "debug",
+      "console": {
+        "json": true,
+        "colorize": false
+      }
+    },
+
+    "rateLimiter": {
+      "enabled": true,
+      "redisHost": "redis",
+      "redisPort": 6379,
+      "requestsPerMinute": 5
+    }
+  },
+  "rendering": {
+    "chromeBin": null,
+    "args": [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-gpu",
+      "--use-gl=swiftshader"
+    ],
+    "ignoresHttpsErrors": false,
+
+    "timezone": null,
+    "acceptLanguage": null,
+    "width": 1000,
+    "height": 500,
+    "deviceScaleFactor": 1,
+    "maxWidth": 3080,
+    "maxHeight": 3000,
+    "maxDeviceScaleFactor": 4,
+
+    "mode": "clustered",
+    "clustering": {
+      "mode": "context",
+      "maxConcurrency": 5,
+      "timeout": 30
+    },
+
+    "verboseLogging": false,
+    "dumpio": false
+  }
+}

--- a/devenv/docker/ratelimiter/config.json
+++ b/devenv/docker/ratelimiter/config.json
@@ -21,7 +21,7 @@
       "enabled": true,
       "redisHost": "redis",
       "redisPort": 6379,
-      "requestsPerMinute": 5
+      "requestsPerSecond": 5
     }
   },
   "rendering": {

--- a/devenv/docker/ratelimiter/docker-compose.yaml
+++ b/devenv/docker/ratelimiter/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000
+    environment:
+      GF_RENDERING_SERVER_URL: http://renderer:8081/render
+      GF_RENDERING_CALLBACK_URL: http://grafana:3000/
+      GF_LOG_FILTERS: rendering:debug
+  renderer:
+    image: custom-grafana-image-renderer
+    ports:
+      - 8081
+    volumes:
+      - ./config.json:/usr/src/app/config.json
+  redis:
+    image: redis:latest
+    ports:
+      - 6379
+
+

--- a/devenv/docker/ratelimiter/docker-compose.yaml
+++ b/devenv/docker/ratelimiter/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
       GF_LOG_FILTERS: rendering:debug
   renderer:
-    image: custom-grafana-image-renderer
+    image: grafana/grafana-image-renderer:latest
     ports:
       - 8081
     volumes:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dompurify": "^3.2.4",
     "express": "^4.21.1",
     "express-prom-bundle": "^6.5.0",
+    "ioredis": "^5.6.1",
     "jimp": "^0.22.12",
     "jsdom": "20.0.0",
     "lodash": "^4.17.21",
@@ -44,6 +45,7 @@
     "prom-client": "^14.1.0",
     "puppeteer": "^22.8.2",
     "puppeteer-cluster": "^0.24.0",
+    "rate-limiter-flexible": "^7.0.0",
     "unique-filename": "^2.0.1",
     "winston": "^3.8.2"
   },
@@ -89,5 +91,6 @@
   "bin": "build/app.js",
   "engines": {
     "node": ">= 20"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,5 @@
   "bin": "build/app.js",
   "engines": {
     "node": ">= 20"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -18,6 +18,13 @@ export interface LoggingConfig {
   console?: ConsoleLoggerConfig;
 }
 
+export interface RateLimiterConfig {
+  enabled: boolean;
+  redisHost?: string;
+  redisPort?: number;
+  limitRps: number;
+}
+
 export interface ServiceConfig {
   service: {
     host?: string;
@@ -29,6 +36,7 @@ export interface ServiceConfig {
     metrics: MetricsConfig;
     logging: LoggingConfig;
     security: SecurityConfig;
+    rateLimiter: RateLimiterConfig;
   };
   rendering: RenderingConfig;
 }
@@ -52,6 +60,10 @@ export const defaultServiceConfig: ServiceConfig = {
     },
     security: {
       authToken: '-',
+    },
+    rateLimiter: {
+      enabled: false,
+      limitRps: 100,
     },
   },
   rendering: defaultRenderingConfig,

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -22,7 +22,7 @@ export interface RateLimiterConfig {
   enabled: boolean;
   redisHost?: string;
   redisPort?: number;
-  requestsPerMinute: number;
+  requestsPerSecond: number;
 }
 
 export interface ServiceConfig {
@@ -63,7 +63,7 @@ export const defaultServiceConfig: ServiceConfig = {
     },
     rateLimiter: {
       enabled: false,
-      requestsPerMinute: 100,
+      requestsPerSecond: 5,
     },
   },
   rendering: defaultRenderingConfig,

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -22,7 +22,7 @@ export interface RateLimiterConfig {
   enabled: boolean;
   redisHost?: string;
   redisPort?: number;
-  limitRps: number;
+  requestsPerMinute: number;
 }
 
 export interface ServiceConfig {
@@ -63,7 +63,7 @@ export const defaultServiceConfig: ServiceConfig = {
     },
     rateLimiter: {
       enabled: false,
-      limitRps: 100,
+      requestsPerMinute: 100,
     },
   },
   rendering: defaultRenderingConfig,

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -52,7 +52,7 @@ const serviceConfig: ServiceConfig = {
     },
     rateLimiter: {
       enabled: false,
-      limitRps: 100,
+      requestsPerMinute: 100,
     },
   },
   rendering: {

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as request from 'supertest';
 import * as pixelmatch from 'pixelmatch';
 import * as fastPng from 'fast-png';
+import * as promClient from 'prom-client';
 
 import { HttpServer } from './http-server';
 import { ConsoleLogger } from '../logger';
@@ -31,7 +32,7 @@ const renderKey = jwt.sign(
 );
 
 const goldenFilesFolder = './tests/testdata';
-const serviceConfig: ServiceConfig = {
+const defaultServiceConfig: ServiceConfig = {
   service: {
     host: undefined,
     port: 8081,
@@ -89,7 +90,7 @@ const imageDiffThreshold = 0.01 * imageHeight * imageWidth;
 const matchingThreshold = 0.3;
 
 const sanitizer = createSanitizer();
-const server = new HttpServer(serviceConfig, new ConsoleLogger(serviceConfig.service.logging), sanitizer);
+let server;
 
 let domain = 'localhost';
 function getGrafanaEndpoint(domain: string) {
@@ -101,7 +102,15 @@ let envSettings = {
   updateGolden: false,
 };
 
-beforeAll(() => {
+beforeEach(async () => {
+  return setupTestEnv();
+});
+
+afterEach(() => {
+  return cleanUpTestEnv();
+});
+
+function setupTestEnv(config?: ServiceConfig) {
   if (process.env['CI'] === 'true') {
     domain = 'grafana';
   }
@@ -109,12 +118,15 @@ beforeAll(() => {
   envSettings.saveDiff = process.env['SAVE_DIFF'] === 'true';
   envSettings.updateGolden = process.env['UPDATE_GOLDEN'] === 'true';
 
+  const currentConfig = config ?? defaultServiceConfig;
+  server = new HttpServer(currentConfig, new ConsoleLogger(currentConfig.service.logging), sanitizer);
   return server.start();
-});
+}
 
-afterAll(() => {
+function cleanUpTestEnv() {
+  promClient.register.clear();
   return server.close();
-});
+}
 
 describe('Test /render/version', () => {
   it('should respond with unauthorized', () => {
@@ -123,7 +135,6 @@ describe('Test /render/version', () => {
 
   it('should respond with the current plugin version', () => {
     const pluginInfo = require('../../plugin.json');
-
     return request(server.app).get('/render/version').set('X-Auth-Token', '-').expect(200, { version: pluginInfo.info.version });
   });
 });
@@ -197,6 +208,17 @@ describe('Test /render', () => {
 
     const pixelDiff = compareImage('full-page-screenshot', response.body);
     expect(pixelDiff).toBeLessThan(imageDiffThreshold);
+  });
+
+  it('should respond with too many requests', async () => {
+    await cleanUpTestEnv();
+    const config = JSON.parse(JSON.stringify(defaultServiceConfig));
+    config.service.rateLimiter.enabled = true;
+    config.service.rateLimiter.requestsPerSecond = 0;
+    await setupTestEnv(config);
+
+    const response = await request(server.app).get('/render').set('X-Auth-Token', '-');
+    expect(response.statusCode).toEqual(429);
   });
 });
 

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -52,7 +52,7 @@ const serviceConfig: ServiceConfig = {
     },
     rateLimiter: {
       enabled: false,
-      requestsPerMinute: 100,
+      requestsPerSecond: 5,
     },
   },
   rendering: {

--- a/src/service/http-server.integration.test.ts
+++ b/src/service/http-server.integration.test.ts
@@ -50,6 +50,10 @@ const serviceConfig: ServiceConfig = {
     security: {
       authToken: '-',
     },
+    rateLimiter: {
+      enabled: false,
+      limitRps: 100,
+    },
   },
   rendering: {
     args: ['--no-sandbox', '--disable-gpu'],
@@ -95,15 +99,15 @@ function getGrafanaEndpoint(domain: string) {
 let envSettings = {
   saveDiff: false,
   updateGolden: false,
-}
+};
 
 beforeAll(() => {
   if (process.env['CI'] === 'true') {
     domain = 'grafana';
   }
-  
-  envSettings.saveDiff = process.env['SAVE_DIFF'] === 'true'
-  envSettings.updateGolden = process.env['UPDATE_GOLDEN'] === 'true'
+
+  envSettings.saveDiff = process.env['SAVE_DIFF'] === 'true';
+  envSettings.updateGolden = process.env['UPDATE_GOLDEN'] === 'true';
 
   return server.start();
 });
@@ -180,14 +184,11 @@ describe('Test /render', () => {
     expect(pixelDiff).toBeLessThan(imageDiffThreshold);
   });
 
-  
   it('should take a full dashboard screenshot', async () => {
     const url = `${getGrafanaEndpoint(domain)}/d/${allPanelsDashboardUid}?render=1&from=1699333200000&to=1699344000000&kiosk=true`;
     const response = await request(server.app)
       .get(
-        `/render?url=${encodeURIComponent(
-          url
-        )}&timeout=5&renderKey=${renderKey}&domain=${domain}&width=${imageWidth}&height=-1&deviceScaleFactor=1`
+        `/render?url=${encodeURIComponent(url)}&timeout=5&renderKey=${renderKey}&domain=${domain}&width=${imageWidth}&height=-1&deviceScaleFactor=1`
       )
       .set('X-Auth-Token', '-');
 

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -69,7 +69,7 @@ export class HttpServer {
     this.app.use('/render', authTokenMiddleware(this.config.service.security), trustedUrlMiddleware);
     const rateLimiterConfig = this.config.service.rateLimiter;
     if (rateLimiterConfig.enabled) {
-      let rateLimiter = setupRateLimiter(rateLimiterConfig);
+      let rateLimiter = setupRateLimiter(rateLimiterConfig, this.log);
       this.app.use('/render', rateLimiterMiddleware(rateLimiter));
     }
 

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -15,10 +15,11 @@ import { Logger } from '../logger';
 import { Browser, createBrowser } from '../browser';
 import { ServiceConfig } from './config';
 import { setupHttpServerMetrics } from './metrics';
+import { setupRateLimiter } from './ratelimiter';
 import { HTTPHeaders, ImageRenderOptions, RenderOptions } from '../types';
 import { Sanitizer } from '../sanitizer/Sanitizer';
 import { isSanitizeRequest } from '../sanitizer/types';
-import { asyncMiddleware, trustedUrlMiddleware, authTokenMiddleware } from './middlewares';
+import { asyncMiddleware, trustedUrlMiddleware, authTokenMiddleware, rateLimiterMiddleware } from './middlewares';
 import { SecureVersion } from 'tls';
 
 const upload = multer({ storage: multer.memoryStorage() });
@@ -66,6 +67,11 @@ export class HttpServer {
 
     // Middlewares for /render endpoints
     this.app.use('/render', authTokenMiddleware(this.config.service.security), trustedUrlMiddleware);
+    const rateLimiterConfig = this.config.service.rateLimiter;
+    if (rateLimiterConfig.enabled) {
+      let rateLimiter = setupRateLimiter(rateLimiterConfig);
+      this.app.use('/render', rateLimiterMiddleware(rateLimiter));
+    }
 
     // Set up /render endpoints
     this.app.get('/render', asyncMiddleware(this.render));

--- a/src/service/middlewares.ts
+++ b/src/service/middlewares.ts
@@ -2,6 +2,7 @@ import express = require('express');
 import * as boom from '@hapi/boom';
 import { ImageRenderOptions } from '../types';
 import { SecurityConfig, isAuthTokenValid } from '../config/security';
+import { RateLimiterAbstract } from 'rate-limiter-flexible';
 
 export const asyncMiddleware = (fn) => (req, res, next) => {
   Promise.resolve(fn(req, res, next)).catch((err) => {
@@ -34,5 +35,22 @@ export const authTokenMiddleware = (config: SecurityConfig) => {
     }
 
     next();
+  };
+};
+
+export const rateLimiterMiddleware = (rateLimiter: RateLimiterAbstract) => {
+  return async (req: express.Request<any, any, any, ImageRenderOptions, any>, res: express.Response, next: express.NextFunction) => {
+    const rateLimiterKey = req.header('X-Tenant-ID') || req.ip;
+    if (rateLimiterKey === undefined) {
+      return next(boom.badRequest('Missing X-Tenant-ID header to use rate limiter'));
+    }
+
+    try {
+      await rateLimiter.consume(rateLimiterKey);
+      next();
+    } catch (err) {
+      res.set('Retry-After', String(Math.ceil(err.msBeforeNext / 1000)));
+      res.status(429).send('Too Many Requests');
+    }
   };
 };

--- a/src/service/ratelimiter.ts
+++ b/src/service/ratelimiter.ts
@@ -16,19 +16,19 @@ export const setupRateLimiter = (config: RateLimiterConfig, log: Logger) => {
     rateLimiter = new RateLimiterRedis({
       storeClient: redisClient,
       keyPrefix: 'rate-limit',
-      points: config.requestsPerMinute, // Maximum number of requests
-      duration: 60, // per 60 seconds
+      points: config.requestsPerSecond, // Maximum number of requests
+      duration: 1, // per second
     });
 
-    log.info('Rate limiter enabled using Redis', 'requestsPerMinute', config.requestsPerMinute);
+    log.info('Rate limiter enabled using Redis', 'requestsPerSecond', config.requestsPerSecond);
   } else {
     // Fallback to in-memory storage
     rateLimiter = new RateLimiterMemory({
-      points: config.requestsPerMinute,
-      duration: 60,
+      points: config.requestsPerSecond,
+      duration: 1,
     });
 
-    log.info('Rate limiter enabled using in-memory storage', 'requestsPerMinute', config.requestsPerMinute);
+    log.info('Rate limiter enabled using in-memory storage', 'requestsPerSecond', config.requestsPerSecond);
   }
 
   return rateLimiter;

--- a/src/service/ratelimiter.ts
+++ b/src/service/ratelimiter.ts
@@ -15,13 +15,13 @@ export const setupRateLimiter = (config: RateLimiterConfig) => {
     rateLimiter = new RateLimiterRedis({
       storeClient: redisClient,
       keyPrefix: 'rate-limit',
-      points: config.limitRps, // Maximum number of requests
+      points: config.requestsPerMinute, // Maximum number of requests
       duration: 60, // per 60 seconds
     });
   } else {
     // Fallback to in-memory storage
     rateLimiter = new RateLimiterMemory({
-      points: config.limitRps,
+      points: config.requestsPerMinute,
       duration: 60,
     });
   }

--- a/src/service/ratelimiter.ts
+++ b/src/service/ratelimiter.ts
@@ -9,8 +9,8 @@ export const setupRateLimiter = (config: RateLimiterConfig, log: Logger) => {
 
   if (config.redisHost && config.redisPort) {
     const redisClient = new Redis({
-      host: config.redisHost || 'localhost',
-      port: config.redisPort || 6379,
+      host: config.redisHost,
+      port: config.redisPort,
     });
 
     rateLimiter = new RateLimiterRedis({

--- a/src/service/ratelimiter.ts
+++ b/src/service/ratelimiter.ts
@@ -2,8 +2,9 @@ import { RateLimiterRedis, RateLimiterMemory } from 'rate-limiter-flexible';
 import { Redis } from 'ioredis';
 
 import { RateLimiterConfig } from './config';
+import { Logger } from '../logger';
 
-export const setupRateLimiter = (config: RateLimiterConfig) => {
+export const setupRateLimiter = (config: RateLimiterConfig, log: Logger) => {
   let rateLimiter;
 
   if (config.redisHost && config.redisPort) {
@@ -18,12 +19,16 @@ export const setupRateLimiter = (config: RateLimiterConfig) => {
       points: config.requestsPerMinute, // Maximum number of requests
       duration: 60, // per 60 seconds
     });
+
+    log.info('Rate limiter enabled using Redis', 'requestsPerMinute', config.requestsPerMinute);
   } else {
     // Fallback to in-memory storage
     rateLimiter = new RateLimiterMemory({
       points: config.requestsPerMinute,
       duration: 60,
     });
+
+    log.info('Rate limiter enabled using in-memory storage', 'requestsPerMinute', config.requestsPerMinute);
   }
 
   return rateLimiter;

--- a/src/service/ratelimiter.ts
+++ b/src/service/ratelimiter.ts
@@ -1,0 +1,30 @@
+import { RateLimiterRedis, RateLimiterMemory } from 'rate-limiter-flexible';
+import { Redis } from 'ioredis';
+
+import { RateLimiterConfig } from './config';
+
+export const setupRateLimiter = (config: RateLimiterConfig) => {
+  let rateLimiter;
+
+  if (config.redisHost && config.redisPort) {
+    const redisClient = new Redis({
+      host: config.redisHost || 'localhost',
+      port: config.redisPort || 6379,
+    });
+
+    rateLimiter = new RateLimiterRedis({
+      storeClient: redisClient,
+      keyPrefix: 'rate-limit',
+      points: config.limitRps, // Maximum number of requests
+      duration: 60, // per 60 seconds
+    });
+  } else {
+    // Fallback to in-memory storage
+    rateLimiter = new RateLimiterMemory({
+      points: config.limitRps,
+      duration: 60,
+    });
+  }
+
+  return rateLimiter;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -2306,6 +2311,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2622,6 +2632,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -3950,6 +3965,21 @@ iobuffer@^5.3.2:
   resolved "https://registry.yarnpkg.com/iobuffer/-/iobuffer-5.3.2.tgz#76d3fb907c655ad6fb7a73964bfca8b4e04f52fa"
   integrity sha512-kO3CjNfLZ9t+tHxAMd+Xk4v3D/31E91rMs1dHrm7ikEQrlZ8mLDbQ4z3tZfDM48zOkReas2jx8MWSAmN9+c8Fw==
 
+ioredis@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.6.1.tgz#1ed7dc9131081e77342503425afceaf7357ae599"
+  integrity sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ip-address@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
@@ -4928,10 +4958,20 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -5926,6 +5966,11 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+rate-limiter-flexible@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-7.0.0.tgz#087d666cbe475452628650d431b1b602cc45f5c4"
+  integrity sha512-K1Y7WTh6m/MpgifDkBzexI0PfPYd+LaXRl+Aqq+LkKKIb68KLJxd/cp+Fw3iU1T0h3oQ9TwbR0m2/ksU70ML+g==
+
 raw-body@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
@@ -6003,6 +6048,18 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -6472,6 +6529,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -6524,7 +6586,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6607,7 +6678,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7312,7 +7390,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7325,6 +7403,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR adds a rate limiter to the server mode of the image renderer.

WIP, what remains:
- [x] Test Redis support
- [x] Test in Docker
- [x] Test when the feature is disabled
- [x] Test in plugin mode (should do nothing as this new feature is not available in plugin mode)
- [x] Run load tests to find a good default

Depends on https://github.com/grafana/grafana/pull/103987

Fixes https://github.com/grafana/grafana-enterprise/issues/7794