### PR TITLE
PDF: Use sent timeout

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -381,6 +381,7 @@ export class Browser {
           });
         }
 
+        const timeoutMs = options.timeout * 1000;
         return page.pdf({
           ...getPDFOptionsFromURL(options.url),
           margin: {
@@ -390,7 +391,7 @@ export class Browser {
             left: 0,
           },
           path: options.filePath,
-          scale: 1 / scale,
+          timeout: timeoutMs,
           timeout: options.timeout * 1000,
         });
       }

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -391,6 +391,7 @@ export class Browser {
           },
           path: options.filePath,
           scale: 1 / scale,
+          timeout: options.timeout,
         });
       }
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -391,8 +391,8 @@ export class Browser {
             left: 0,
           },
           path: options.filePath,
+          scale: 1 / scale,
           timeout: timeoutMs,
-          timeout: options.timeout * 1000,
         });
       }
 

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -391,7 +391,7 @@ export class Browser {
           },
           path: options.filePath,
           scale: 1 / scale,
-          timeout: options.timeout,
+          timeout: options.timeout * 1000,
         });
       }
 


### PR DESCRIPTION
The `.pdf` function currently uses the default timeout (30s) instead of the provided timeout as every other function during the rendering process.

When printing a PDF for a very large dashboard, this leads to not being able to customize the timeout.