### PR TITLE
CI: Fix Docker secrets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -279,9 +279,9 @@ steps:
   - yarn-test
   environment:
     DOCKER_PASS:
-      from_secret: docker_pass
+      from_secret: docker_password
     DOCKER_USER:
-      from_secret: docker_user
+      from_secret: docker_username
     IMAGE_NAME: grafana/grafana-image-renderer
   image: google/cloud-sdk:449.0.0
   name: publish_to_docker_master
@@ -456,9 +456,9 @@ steps:
   - publish_to_github
   environment:
     DOCKER_PASS:
-      from_secret: docker_pass
+      from_secret: docker_password
     DOCKER_USER:
-      from_secret: docker_user
+      from_secret: docker_username
     IMAGE_NAME: grafana/grafana-image-renderer
   image: google/cloud-sdk:449.0.0
   name: publish_to_docker
@@ -541,7 +541,19 @@ get:
 kind: secret
 name: gar
 ---
+get:
+  name: username
+  path: ci/data/common/dockerhub
+kind: secret
+name: docker_username
+---
+get:
+  name: password
+  path: ci/data/common/dockerhub
+kind: secret
+name: docker_password
+---
 kind: signature
-hmac: 4dba0a92e353db7897b48eca1db87b5736aef14d23e987e0845a887b3103c90c
+hmac: 15d030deddf602f0edf703164e7049ff4bccc23f795995e4f7a3050452a25069
 
 ...

--- a/scripts/drone/promotion.star
+++ b/scripts/drone/promotion.star
@@ -42,8 +42,8 @@ def publish_to_docker():
         'image': 'google/cloud-sdk:449.0.0',
         'environment': {
             'IMAGE_NAME': docker_image,
-            'DOCKER_USER': from_secret('docker_user'),
-            'DOCKER_PASS': from_secret('docker_pass'),
+            'DOCKER_USER': from_secret('docker_username'),
+            'DOCKER_PASS': from_secret('docker_password'),
         },
         'commands': ['./scripts/build_push_docker.sh'],
         'volumes': [{'name': 'docker', 'path': '/var/run/docker.sock'}],

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -24,4 +24,6 @@ def secrets():
         vault_secret('grafana_api_key', 'infra/data/ci/drone-plugins', 'grafana_api_key'),
         vault_secret('srcclr_api_token', 'infra/data/ci/drone-plugins', 'srcclr_api_token'),
         vault_secret(gar_pull_secret, 'secret/data/common/gar', '.dockerconfigjson'),
+        vault_secret('docker_username', 'ci/data/common/dockerhub', 'username'),
+        vault_secret('docker_password', 'ci/data/common/dockerhub', 'password'),
     ]


### PR DESCRIPTION
Current Docker secrets defined in Drone are no longer working. Moving to using secrets in Vault.