### PR TITLE
Tracing: Fix tracing headers causing CORS issue

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -568,7 +568,7 @@ export class Browser {
     return callback();
   }
 
-  async addPageListeners(page: puppeteer.Page, headers) {
+  async addPageListeners(page: puppeteer.Page, headers: HTTPHeaders) {
     page.on('error', this.logError);
     page.on('pageerror', this.logPageError);
     page.on('requestfailed', this.logRequestFailed);
@@ -627,7 +627,7 @@ export class Browser {
           headers['tracestate'] = optionsHeaders['tracestate'] ?? '';
         }
       } catch (error) {
-        this.log.debug('Failed to remove tracing header', 'url', url, 'referer', referer, 'error', error.message);
+        this.log.debug('Failed to add tracing headers', 'url', url, 'referer', referer, 'error', error.message);
       }
 
       req.continue({ headers });

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -568,7 +568,7 @@ export class Browser {
     return callback();
   }
 
-  async addPageListeners(page: puppeteer.Page, headers: HTTPHeaders) {
+  async addPageListeners(page: puppeteer.Page, headers?: HTTPHeaders) {
     page.on('error', this.logError);
     page.on('pageerror', this.logPageError);
     page.on('requestfailed', this.logRequestFailed);

--- a/src/browser/clustered.ts
+++ b/src/browser/clustered.ts
@@ -79,7 +79,7 @@ export class ClusteredBrowser extends Browser {
       }
 
       try {
-        await this.addPageListeners(page);
+        await this.addPageListeners(page, options.headers);
         switch (renderType) {
           case RenderType.CSV:
             return await this.exportCSV(page, options, signal);

--- a/src/browser/reusable.ts
+++ b/src/browser/reusable.ts
@@ -32,7 +32,7 @@ export class ReusableBrowser extends Browser {
         await page.emulateTimezone(options.timezone);
       }
 
-      await this.addPageListeners(page);
+      await this.addPageListeners(page, options.headers);
 
       return await this.takeScreenshot(page, options, signal);
     } finally {
@@ -60,7 +60,7 @@ export class ReusableBrowser extends Browser {
         await page.emulateTimezone(options.timezone);
       }
 
-      await this.addPageListeners(page);
+      await this.addPageListeners(page, options.headers);
 
       return await this.exportCSV(page, options, signal);
     } finally {


### PR DESCRIPTION
It seems that `page.on('request', ...)` isn't triggered on EVERY request so adding the headers for every request and removing them here wasn't working for some requests.

This is achieving the same result, the other way around, only adding headers for requests we are sure we should add them.