### PR TITLE
Chore: Update base Docker image to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.12.7 (2025-06-19)
+
+- Chore: Update base Docker image to latest, [macabu](https://github.com/macabu)
+- Tracing: Add debug logs when verbose logging is enabled [#644](https://github.com/grafana/grafana-image-renderer/pull/644), [AgnesToulet](https://github.com/AgnesToulet)
+
 ## 3.12.6 (2025-05-23)
 
 - Chore: Upgrade multer 2.0.0 [#642](https://github.com/grafana/grafana-image-renderer/pull/642), [evictorero](https://github.com/evictorero)

--- a/plugin.json
+++ b/plugin.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "3.12.6",
-    "updated": "2025-05-23"
+    "version": "3.12.7",
+    "updated": "2025-06-19"
   },
   "dependencies": {
     "grafanaDependency": ">=8.3.11"


### PR DESCRIPTION
Bumps the base `node:20-alpine` image to latest to trigger a new release.