### PR TITLE
Codeowners: Update ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/grafana-operator-experience-squad

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN yarn install --pure-lockfile --production
 FROM base
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
-LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 ARG GF_UID="472"
 ARG GF_GID="472"


### PR DESCRIPTION
Grafana Enterprise now owns the repository.

Also updating the Dockerfile to point to the right file, so as to hopefully fix Grafana VulnO11y's ownership attribution.