### PR TITLE
Docker: Update base Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.12.8 (2025-06-25)
+
+- Chore: Update base Docker image to latest (CVE-2025-6191, CVE-2025-6192), [#654](https://github.com/grafana/grafana-image-renderer/pull/654), [Proximyst](https://github.com/Proximyst)
+
 ## 3.12.7 (2025-06-19)
 
 - Chore: Update base Docker image to latest (CVE-2025-5959), [#647](https://github.com/grafana/grafana-image-renderer/pull/647), [#648](https://github.com/grafana/grafana-image-renderer/pull/648), [macabu](https://github.com/macabu), [Proximyst](https://github.com/Proximyst)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/src/app
 # Can be back to stable when 3.22 gets .103.
 RUN apk --no-cache upgrade && \
     apk add --no-cache udev ttf-opensans unifont ca-certificates dumb-init && \
-    apk add --no-cache chromium chromium-swiftshader --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
+    apk add --no-cache 'chromium>=137.0.7151.119' 'chromium-swiftshader>=137.0.7151.119' --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
     # Remove NPM-related files and directories
     rm -rf /usr/local/lib/node_modules/npm && \
     rm -rf /usr/local/bin/npm && \

--- a/plugin.json
+++ b/plugin.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "3.12.7",
-    "updated": "2025-06-19"
+    "version": "3.12.8",
+    "updated": "2025-06-25"
   },
   "dependencies": {
     "grafanaDependency": ">=8.3.11"


### PR DESCRIPTION
We need to rebuild the Docker image again, as Chromium has updated.

To ensure we can trust we have AT LEAST the version we want, I've also added the version constraint into the Dockerfile. It isn't reproducible, as it is NOT a pin, but it does verify we have the minimum fixed version.

Fixes: CVE-2025-6191
Fixes: CVE-2025-6192