### PR TITLE
Docker: Update Chromium in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/src/app
 # Can be back to stable when 3.22 gets .103.
 RUN apk --no-cache upgrade && \
     apk add --no-cache udev ttf-opensans unifont ca-certificates dumb-init && \
-    apk add --no-cache 'chromium>=137.0.7151.119' 'chromium-swiftshader>=137.0.7151.119' --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
+    apk add --no-cache 'chromium>=138.0.7204.93' 'chromium-swiftshader>=138.0.7204.93' --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community && \
     # Remove NPM-related files and directories
     rm -rf /usr/local/lib/node_modules/npm && \
     rm -rf /usr/local/bin/npm && \


### PR DESCRIPTION
Chromium released 138.0.7204.93. Let's update to it.