### PR TITLE
Actions: Upload correct md5sums.txt path

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -147,7 +147,7 @@ jobs:
         with:
           files: |
             artifacts/*.zip
-            md5sums.txt
+            artifacts/md5sums.txt
           fail_on_unmatched_files: true
           make_latest: 'true'
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 4.0.1 (2025-07-22)
+## 4.0.1 & 4.0.2 (2025-07-22)
 
-This release only touches the build process of the plugin, as v4.0.0 did not release on the plugin catalog.
+This release only touches the build process of the plugin, as v4.0.0 and v4.0.1 did not release on the plugin catalog.
 There is no difference from v4.0.0 for Docker users.
 
 ## 4.0.0 (2025-07-22)

--- a/docs/release_new_version.md
+++ b/docs/release_new_version.md
@@ -1,41 +1,27 @@
 # Release and publish a new version
 
-1. Every commit to master is a possible release.
-2. Version in plugin.json is used for deciding which version to release.
+Remember that every commit to master is a possible release.
 
 ## Prepare
 
 1. Update `version` and `updated` properties in plugin.json.
 2. Update CHANGELOG.md.
 3. Merge/push changes to master.
-4. Commit is built in [Drone](https://drone.grafana.net/grafana/grafana-image-renderer).
 
-## Promote release
+## Release
 
-1. Open [Drone](https://drone.grafana.net/grafana/grafana-image-renderer) and find the build for your commit.
-2. Click on the `...` from the top-right corner to display the menu, then click on `Promote`.
-3. Fill the `Create deployment` form with the values below, and click on `Deploy`:
-    - `Type` = `Promote`
-    - `Target` = `release` *(write it manually)*
-    - *(no parameters needed)*
-4. Once you've clicked on `Deploy` it will trigger a new pipeline with the release steps.
-
-## Publish plugin to Grafana.com
-
-Since the [migration to Drone](https://github.com/grafana/grafana-image-renderer/pull/394), this step that historically
-was needed to be performed manually is no longer required and is automatically performed by `publish_to_gcom` step.
-
-**Note:** The step will time out, but the plugin update process will continue in the background.
+Tag a new version, either in the GitHub UI or pushing it from the CLI:
 
 ```
-<html>
-<head><title>504 Gateway Time-out</title></head>
-<body>
-<center><h1>504 Gateway Time-out</h1></center>
-<hr><center>nginx/1.17.9</center>
-</body>
-</html>
+$ git switch master
+$ git fetch
+$ git reset --hard origin/master
+$ git tag v0.0.0
+$ git push origin v0.0.0
 ```
+
+GitHub Actions takes care of _everything_ until you get to the Grafana Cloud deployment.
 
 ## Deploy into Grafana Cloud
+
 Create a PR in [Deployment Tools](https://github.com/grafana/deployment_tools/blob/master/ksonnet/lib/render-service/images.libsonnet) with the new version.

--- a/plugin.json
+++ b/plugin.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "4.0.1",
+    "version": "4.0.2",
     "updated": "2025-07-22"
   },
   "dependencies": {


### PR DESCRIPTION
I had forgotten that the `upload-artifacts` action will only not keep parent dirs if all files are in the same place 🙄 