### PR TITLE
Actions: Include download URLs

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -144,6 +144,7 @@ jobs:
             GRAFANA_ACCESS_POLICY_TOKEN=gcom-token:token
 
       - uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
+        id: release
         with:
           files: |
             artifacts/*.zip
@@ -151,13 +152,44 @@ jobs:
           fail_on_unmatched_files: true
           make_latest: 'true'
           generate_release_notes: true
-      - run: |
+      - name: Add download URLs to gcom.json
+        env:
+          ASSETS: ${{ steps.release.outputs.assets }}
+        run: |
+          set -euo pipefail
+          # ASSETS is a JSON array of objects: {name, browser_download_url}
+          # We want to modify gcom.json to have a `$.download` field which has the structure:
+          # {"existing-key-here": {"md5": "existing value from previous file", "url": "browser_download_url"}}
+          # where the `name` is used to map from `plugin-linux-x64-glibc.zip` to `linux-amd64`, etc.
+          jq --argjson assets "$ASSETS" '
+            .download as $old
+            | .download = (
+                $assets
+                | map(
+                    . as $a
+                    | (
+                        $a.name
+                        | sub("^plugin-"; "")
+                        | sub("-unknown"; "")
+                        | sub("-glibc"; "")
+                        | sub("win32"; "windows")
+                        | sub("x64"; "amd64")
+                        | sub(".zip$"; "")
+                      ) as $key
+                    | { ($key): { md5: $old[$key], url: $a.browser_download_url } }
+                  )
+                | add
+              )
+          ' gcom.json > with-urls.json
+
+      - name: Publish to grafana.com
+        run: |
           set -euo pipefail
           curl --silent --show-error \
             --header 'User-Agent: grafana-image-renderer:/plugins/publish' \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Bearer '"$GRAFANA_ACCESS_POLICY_TOKEN" \
             --request POST \
-            --data @gcom.json \
+            --data @with-urls.json \
             --location \
             https://grafana.com/api/plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 4.0.1 & 4.0.2 (2025-07-22)
+## 4.0.1, 4.0.2 & 4.0.3 (2025-07-22)
 
-This release only touches the build process of the plugin, as v4.0.0 and v4.0.1 did not release on the plugin catalog.
+This release only touches the build process of the plugin, as v4.0.0, .1, and .2 did not release on the plugin catalog.
 There is no difference from v4.0.0 for Docker users.
 
 ## 4.0.0 (2025-07-22)

--- a/plugin.json
+++ b/plugin.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "4.0.2",
+    "version": "4.0.3",
     "updated": "2025-07-22"
   },
   "dependencies": {


### PR DESCRIPTION
Example:

```shell
$ echo $ASSETS
[{"name": "plugin-linux-x64-glibc.zip", "browser_download_url": "localhost"}, {"name": "plugin-darwin-x64-unknown.zip", "browser_download_url": "localhost2"}, {"name": "plugin-win32-x64-unknown.zip", "browser_download_url": "localhost3"}]

$ echo '{
    "commit": "2410094decc39da9a8d87c741ac7a1aeb1aaf516",
    "url": "https://github.com/grafana/grafana-image-renderer",
    "download": {
      "darwin-amd64": "3b2b2ee39d2a1b012593f58d10ce5e69",
      "linux-amd64": "2e9cd1d9ad849390e2b35ebc4e861b20",
      "windows-amd64": "a3e790860d27cd4fe4dc9bb24a56c155"
    }
  }' | jq --argjson assets "$ASSETS" '
              .download as $old
              | .download = (
                  $assets
                  | map(
                      . as $a
                      | (
                          $a.name
                          | sub("^plugin-"; "")
                          | sub("-unknown"; "")
                          | sub("-glibc"; "")
                          | sub("win32"; "windows")
                          | sub("x64"; "amd64")
                          | sub(".zip$"; "")
                        ) as $key
                      | { ($key): { md5: $old[$key], url: $a.browser_download_url } }
                    )
                  | add
                )
            '
{
  "commit": "2410094decc39da9a8d87c741ac7a1aeb1aaf516",
  "url": "https://github.com/grafana/grafana-image-renderer",
  "download": {
    "linux-amd64": {
      "md5": "2e9cd1d9ad849390e2b35ebc4e861b20",
      "url": "localhost"
    },
    "darwin-amd64": {
      "md5": "3b2b2ee39d2a1b012593f58d10ce5e69",
      "url": "localhost2"
    },
    "windows-amd64": {
      "md5": "a3e790860d27cd4fe4dc9bb24a56c155",
      "url": "localhost3"
    }
  }
}
```