### PR TITLE
Docker: Use tini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.5 (2025-07-23)
+
+- Docker: Use tini
+  - This fixes #677, reported by [@mbentley](https://github.com/mbentley). Thanks!
+
 ## 4.0.1, 4.0.2, 4.0.3 & 4.0.4 (2025-07-22)
 
 This release only touches the build process of the plugin, as v4.0.0, .1, .2, and .3 did not release on the plugin catalog.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'cachebuster 2025-07-16' && apt-get update
 
 FROM debian-updated AS debs
 
-RUN apt-cache depends chromium chromium-driver chromium-shell chromium-sandbox font-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 unifont fonts-open-sans fonts-roboto fonts-inter bash busybox util-linux openssl \
+RUN apt-cache depends chromium chromium-driver chromium-shell chromium-sandbox font-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 unifont fonts-open-sans fonts-roboto fonts-inter bash busybox util-linux openssl tini \
     --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --no-pre-depends | grep '^\w' | xargs apt-get download
 RUN mkdir /dpkg && \
     find . -type f -name '*.deb' -exec sh -c 'dpkg --extract "$1" /dpkg || exit 5' sh '{}' \;
@@ -56,4 +56,5 @@ COPY --from=build /src/plugin.json plugin.json
 
 EXPOSE 8081
 
+ENTRYPOINT ["tini", "--", "/nodejs/bin/node"]
 CMD ["build/app.js", "server", "--config=config.json"]

--- a/plugin.json
+++ b/plugin.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "4.0.4",
+    "version": "4.0.5",
     "updated": "2025-07-22"
   },
   "dependencies": {


### PR DESCRIPTION
When migrating to distroless Debian, we dropped the init process. This leaves defunct processes behind along with improper signal handling. We can use tini to fix this easily.

Fixes: #677