### PR TITLE
Docker: Use numeric UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.9 (2025-07-28)
+
+- Docker: Use numeric UID, [#686](https://github.com/grafana/grafana-image-renderer/issues/686), [Proximyst](https://github.com/Proximyst)
+  - This fixes #686, which is useful for some Kubernetes users. It was reported by [@mhulscher](https://github.com/mhulscher). Thanks!
+  - The bug only manifests if you use `securityContext.runAsNonRoot` in your `Deployment`.
+
 ## 4.0.8 (2025-07-28)
 
 - Docker: Include libnss3-tools, [#685](https://github.com/grafana/grafana-image-renderer/pull/685), [Proximyst](https://github.com/Proximyst), [roock](https://github.com/roock)

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,5 +64,9 @@ COPY --from=build /src/plugin.json plugin.json
 
 EXPOSE 8081
 
+# Simple regression test for: https://github.com/grafana/grafana-image-renderer/issues/686
+RUN test "$(id -u)" -eq 65532
+USER 65532
+
 ENTRYPOINT ["tini", "--", "/nodejs/bin/node"]
 CMD ["build/app.js", "server", "--config=config.json"]

--- a/plugin.json
+++ b/plugin.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "4.0.8",
+    "version": "4.0.9",
     "updated": "2025-07-28"
   },
   "dependencies": {


### PR DESCRIPTION
Kubernetes requires this if users configure the service to run with non-root users.

Fixes: https://github.com/grafana/grafana-image-renderer/issues/686