### PR TITLE
Docker: Inherit permissions from user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Docker: Update Chromium (CVE-2025-8292), [#695](https://github.com/grafana/grafana-image-renderer/pull/695), [macabu](https://github.com/macabu)
 - Tests: Add Docker image test suite, [#693](https://github.com/grafana/grafana-image-renderer/pull/693), [Proximyst](https://github.com/Proximyst)
+- Docker: Inherit permissions from user, [#697](https://github.com/grafana/grafana-image-renderer/pull/697), [Proximyst](https://github.com/Proximyst)
+  - This fixes #694, which applies to RedHat OpenShift users. It was reported by [@mcapala](https://github.com/mcapala). Thanks!
 
 ## 4.0.9 (2025-07-28)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY --from=build /src/plugin.json plugin.json
 
 USER root
 
-RUN chown -R nonroot:0 /home/nonroot && chmod -R go=u /home/nonroot
+RUN chgrp -R 0 /home/nonroot && chmod -R g=u /home/nonroot
 
 USER 65532
 

--- a/tests/bats/regression-694.bats
+++ b/tests/bats/regression-694.bats
@@ -11,7 +11,11 @@ function teardown() {
 @test "openshift: docker image starts with random UID" {
     # We want the container to start and be healthy.
     RANDOM_UID="$(shuf -i 100000-999999 -n 1)"
-    run _docker run --user "$RANDOM_UID":"$RANDOM_UID" --health-start-period=1s --health-start-interval=0.1s --name "$(_container_name)" --rm -d "$DOCKER_IMAGE"
+    # https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/creating-images#use-uid_create-images
+    #   > Because the container user is always a member of the root group, the container user can read and write these files.
+    # https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids
+    #   > Notice the Container is using the UID from the Namespace. An important detail to notice is that the user in the Container always has GID=0, which is the root group. 
+    run _docker run --user "$RANDOM_UID":0 --health-start-period=1s --health-start-interval=0.1s --name "$(_container_name)" --rm -d "$DOCKER_IMAGE"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 


### PR DESCRIPTION
When OpenShift runs, it will assign any arbitrary user to the container, and will always use the root group.

When we run in OpenShift, we therefore want the group ID of all files to be 0.
When we run in Docker/Kubernetes (containerd), we want the user ID to own the files.
These are not overlapping, so we can support both at once.

Fixes: #694