### PR TITLE
Tests: Keep containers around to print logs

### DIFF
--- a/tests/bats/chromium-exists.bats
+++ b/tests/bats/chromium-exists.bats
@@ -9,21 +9,21 @@ function teardown() {
 @test "chromium is installed in CHROME_BIN's location" {
     # Extract the CHROME_BIN variable
     # shellcheck disable=SC2016 # we intentionally use single quotes to avoid variable expansion
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'echo $CHROME_BIN'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'echo $CHROME_BIN'
     [ "$status" -eq 0 ]
     [ -n "$output" ]
     CHROME_BIN="$output"
 
     # Check if the file exists
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c "test -f '$CHROME_BIN'"
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c "test -f '$CHROME_BIN'"
     [ "$status" -eq 0 ]
 
     # Check if the file is executable
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c "test -x '$CHROME_BIN'"
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c "test -x '$CHROME_BIN'"
     [ "$status" -eq 0 ]
 
     # Check it returns its version
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c "'$CHROME_BIN' --version"
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c "'$CHROME_BIN' --version"
     [ "$status" -eq 0 ]
     [[ "$output" =~ ^Chromium\ [0-9]+ ]]
 }

--- a/tests/bats/regression-676.bats
+++ b/tests/bats/regression-676.bats
@@ -10,21 +10,21 @@ function teardown() {
 
 @test "docker image contains openssl tools" {
     # The openssl tools are required to convert from PEM to CRT format.
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'openssl version'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'openssl version'
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }
 
 @test "docker image contains update-ca-certificates" {
     # We need a way to regenerate the CA certificate bundle.
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'command -v update-ca-certificates'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'command -v update-ca-certificates'
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }
 
 @test "docker image contains certutil" {
     # certutil is required to load the CA certificate bundle into NSS, which is used by Chromium.
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'command -v certutil'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'command -v certutil'
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }

--- a/tests/bats/regression-680.bats
+++ b/tests/bats/regression-680.bats
@@ -12,12 +12,12 @@ function teardown() {
     # The LANG environment variable should be set to en_US.UTF-8, which makes Chromium able to deal with non-ASCII characters properly.
 
     # shellcheck disable=SC2016 # we want to avoid variable expansion here
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'echo $LANG'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'echo $LANG'
     [ "$status" -eq 0 ]
     [ "$output" = "en_US.UTF-8" ]
 
     # shellcheck disable=SC2016 # we want to avoid variable expansion here
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'echo $LC_ALL'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'echo $LC_ALL'
     [ "$status" -eq 0 ]
     [ "$output" = "en_US.UTF-8" ]
 }
@@ -27,7 +27,7 @@ function teardown() {
 
     # With LC_ALL=C, sorting is byte-wise. With LC_ALL=en_US.UTF-8, sorting is character-wise.
     # We can use this to ensure we are not using the C locale.
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'echo -e "a\nb\nA\nB" | sort'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'echo -e "a\nb\nA\nB" | sort'
     [ "$status" -eq 0 ]
     # With LC_ALL=C, the output would be "A\nB\na\nb"
     echo "$output"

--- a/tests/bats/regression-686.bats
+++ b/tests/bats/regression-686.bats
@@ -20,7 +20,7 @@ function teardown() {
     run _docker image inspect --format '{{json .Config.User}}' "$DOCKER_IMAGE"
     [ "$status" -eq 0 ]
     IMG_USER="${output//\"/}" # strip the quotes around the JSON value
-    run _docker run --entrypoint sh --user nonroot --rm "$DOCKER_IMAGE" -c 'id -u'
+    run _docker run --entrypoint sh --user nonroot --name "$(_container_name)" "$DOCKER_IMAGE" -c 'id -u'
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "$IMG_USER" ]
 }

--- a/tests/bats/regression-694.bats
+++ b/tests/bats/regression-694.bats
@@ -15,7 +15,7 @@ function teardown() {
     #   > Because the container user is always a member of the root group, the container user can read and write these files.
     # https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids
     #   > Notice the Container is using the UID from the Namespace. An important detail to notice is that the user in the Container always has GID=0, which is the root group. 
-    run _docker run --user "$RANDOM_UID":0 --health-start-period=1s --health-start-interval=0.1s --name "$(_container_name)" --rm -d "$DOCKER_IMAGE"
+    run _docker run --user "$RANDOM_UID":0 --health-start-period=1s --health-start-interval=0.1s --name "$(_container_name)" -d "$DOCKER_IMAGE"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 

--- a/tests/bats/service-starts.bats
+++ b/tests/bats/service-starts.bats
@@ -8,14 +8,14 @@ function teardown() {
 
 @test "docker image has wget" {
     # wget is used in the healthcheck we ship.
-    run _docker run --entrypoint sh --rm "$DOCKER_IMAGE" -c 'command -v wget'
+    run _docker run --entrypoint sh --name "$(_container_name)" "$DOCKER_IMAGE" -c 'command -v wget'
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }
 
 @test "docker image starts" {
     # We want the container to start and be healthy.
-    run _docker run --health-start-period=1s --health-start-interval=0.1s --rm --name "$(_container_name)" -d "$DOCKER_IMAGE"
+    run _docker run --health-start-period=1s --health-start-interval=0.1s --name "$(_container_name)" -d "$DOCKER_IMAGE"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 


### PR DESCRIPTION
This will now keep test containers around long enough to print their logs. We'll still clean them up after the test ends like usual, on both test failure and success.

If you now fail a test, it'll print the logs, e.g.:

```
regression-694.bats
 ✗ openshift: docker image starts with random UID
   (from function `_wait_for_healthy' in file tests/bats/docker.bash, line 64,
    in test file tests/bats/regression-694.bats, line 23)
     `_wait_for_healthy "$output"' failed
   error: container 7efd53ae0664926976cf6ee2c3c5915eaa634ae42e10d57c6d7d47cc0eff73a3 is not running
   node:internal/modules/cjs/loader:1404
     throw err;
     ^

   Error: Cannot find module '/home/nonroot/build/app.js'
       at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
       at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
       at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
       at Function._load (node:internal/modules/cjs/loader:1211:37)
       at TracingChannel.traceSync (node:diagnostics_channel:322:14)
       at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
       at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
       at node:internal/main/run_main_module:36:49 {
     code: 'MODULE_NOT_FOUND',
     requireStack: []
   }

   Node.js v22.17.1
   info: removed container 7efd53ae0664
```