### PR TITLE
Renovate: Configure for Dockerfile only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
     "ignorePresets": [
-        "github>grafana/grafana-renovate-config//presets/base",
         "github>grafana/grafana-renovate-config//presets/automerge",
         "github>grafana/grafana-renovate-config//presets/labels",
         "github>grafana/grafana-renovate-config//presets/security",
@@ -10,4 +9,3 @@
         "github>grafana/grafana-renovate-config//presets/rate-limits"
     ]
   }
-  

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
         "github>grafana/grafana-renovate-config//presets/security",
         "github>grafana/grafana-renovate-config//presets/github-actions",
         "github>grafana/grafana-renovate-config//presets/helm",
-        "github>grafana/grafana-renovate-config//presets/shared-workflows",
-        "github>grafana/grafana-renovate-config//presets/rate-limits"
+        "github>grafana/grafana-renovate-config//presets/shared-workflows"
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+    "ignorePresets": [
+        "github>grafana/grafana-renovate-config//presets/base",
+        "github>grafana/grafana-renovate-config//presets/automerge",
+        "github>grafana/grafana-renovate-config//presets/labels",
+        "github>grafana/grafana-renovate-config//presets/security",
+        "github>grafana/grafana-renovate-config//presets/github-actions",
+        "github>grafana/grafana-renovate-config//presets/helm",
+        "github>grafana/grafana-renovate-config//presets/shared-workflows",
+        "github>grafana/grafana-renovate-config//presets/rate-limits"
+    ]
+  }

--- a/renovate.json
+++ b/renovate.json
@@ -10,3 +10,4 @@
         "github>grafana/grafana-renovate-config//presets/rate-limits"
     ]
   }
+  


### PR DESCRIPTION
Opt out of all other default feature presets for renovate except dockerfile ([reference](https://github.com/grafana/grafana-renovate-config/blob/main/README.md#opting-out-of-presets))

Will not automerge yet, need to confirm everything works first