### PR TITLE
feat(renovate): explicitly disable npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
         "github>grafana/grafana-renovate-config//presets/github-actions",
         "github>grafana/grafana-renovate-config//presets/helm",
         "github>grafana/grafana-renovate-config//presets/shared-workflows"
-    ]
-  }
+    ],
+    "npm": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
Disables `npm` updates, since the PRs that renovate creates are noisy and broken.