### PR TITLE
feat(renovate): explicitly disable node updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
         "github>grafana/grafana-renovate-config//presets/helm",
         "github>grafana/grafana-renovate-config//presets/shared-workflows"
     ],
-    "npm": {
-        "enabled": false
-    },
-    "node": {
-        "enabled": false
-    }
+    "npm": {"enabled": false},
+    "packageRules": [{"matchCategories": ["node"], "enabled": false}]
 }


### PR DESCRIPTION
Disables node updates, since the PRs that renovate creates are noisy and broken.

Similar to: https://github.com/grafana/grafana-image-renderer/pull/724