### PR TITLE
PNG-8 greyscaling to allow rendering on e-ink displays

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -6,6 +6,8 @@ import path from 'path';
 import fs from 'fs';
 import promClient from 'prom-client';
 import Jimp from 'jimp';
+import configure from "@jimp/custom";
+import png from "@jimp/png";
 import { Logger } from '../logger';
 import { RenderingConfig } from '../config/rendering';
 import { HTTPHeaders, ImageRenderOptions, RenderOptions } from '../types';
@@ -417,6 +419,22 @@ export class Browser {
           .writeAsync(scaled);
 
         fs.renameSync(scaled, options.filePath);
+      });
+    }
+
+    if (options.greyScaleImage && !isPDF) {
+      await this.performStep('greyScale', options.url, signal, async () => {
+        const jimp = configure({ types: [png] }, Jimp);
+        const greyScaled = `${options.filePath}_${Date.now()}_greyscaled.png`;
+
+        const file = await jimp.read(options.filePath);
+        await file
+          .greyscale()
+          .deflateStrategy(0)
+          .colorType(0)
+          .writeAsync(greyScaled);
+
+        fs.renameSync(greyScaled, options.filePath);
       });
     }
 

--- a/src/service/http-server.ts
+++ b/src/service/http-server.ts
@@ -203,6 +203,7 @@ export class HttpServer {
       timezone: req.query.timezone,
       encoding: req.query.encoding,
       deviceScaleFactor: req.query.deviceScaleFactor,
+      greyScaleImage: req.query.greyScaleImage,
       headers: this.getHeaders(req),
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,4 +24,5 @@ export interface ImageRenderOptions extends RenderOptions {
   // Runtime options derived from the input
   fullPageImage?: boolean;
   scaleImage?: number;
+  greyScaleImage?: boolean;
 }


### PR DESCRIPTION
This feature is very usefull if grafana should render on an eInk display with greyscale only. I use it for a jailbreaked kindle.

This implementation does not allow to pass the _greyScaleImage_ flag in the render url. Maybe some of you can point me to the right line of code. Until this it's necessary to send the arg in the URL of the renderer in docker config.

```
 grafana:
    [...]
    environment:
      - GF_INSTALL_PLUGINS=grafana-image-renderer
      - GF_RENDERING_SERVER_URL=http://renderer:8081/render?greyScaleImage=true
    [...]
```