### PR TITLE
HTTPServer: Dynamically create and clean up XDG dirs on each request if not exists

### DIFF
--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -122,13 +122,16 @@ export class Browser {
     }
   }
 
-  getLauncherOptions(options) {
+  getLauncherOptions(options: Partial<RenderOptions>) {
     const env = Object.assign({}, process.env);
     // set env timezone
     env.TZ = options.timezone || this.config.timezone;
 
     const launcherOptions: PuppeteerLaunchOptions = {
-      env: env,
+      env: {
+        ...env,
+        ...(options.extraEnv && { ...options.extraEnv }),
+      },
       ignoreHTTPSErrors: this.config.ignoresHttpsErrors,
       dumpio: this.config.dumpio,
       args: this.config.args,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface RenderOptions {
   timezone?: string;
   encoding?: string;
   headers?: HTTPHeaders;
+  extraEnv?: typeof process.env;
 }
 
 export interface ImageRenderOptions extends RenderOptions {


### PR DESCRIPTION
If the `XDG_CACHE_HOME` and/or `XDG_CONFIG_HOME` env vars are not set, we create a temp dir per requests to protect tenant boundary and delete it up when the request finishes.

Fixes https://github.com/grafana/grafana-image-renderer/issues/748

It was noted that in some Linux environments such as OpenShift, the lack of those environment variables caused a crash in Chromium when attempting to render:
```
Otherwise errors like this one would happen:

  Error: Failed to launch the browser process!
  chrome_crashpad_handler: --database is required
```