### PR TITLE
feat(go): add more metrics and traces

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-image-renderer/pkg/traces"
 	"github.com/urfave/cli/v3"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func NewCmd() *cli.Command {
@@ -69,6 +70,7 @@ func run(ctx context.Context, c *cli.Command) error {
 		defer func() { _ = tracerProvider.Shutdown(ctx) }()
 		ctx = traces.WithTracerProvider(ctx, tracerProvider)
 		otel.SetTracerProvider(tracerProvider)
+		otel.SetTextMapPropagator(propagation.TraceContext{})
 	}
 	browser := service.NewBrowserService(c.String("browser"), c.StringSlice("browser-flags"),
 		service.WithViewport(1000, 500),

--- a/devenv/docker/go-build/dashboards/grafana-image-renderer.json
+++ b/devenv/docker/go-build/dashboards/grafana-image-renderer.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 0,
   "links": [],
   "panels": [
     {
@@ -214,7 +214,7 @@
             "uid": "${prom}"
           },
           "editorMode": "code",
-          "expr": "sum by(path) (increase(http_request_duration_count{job=\"image-renderer\"}[$__rate_interval]))",
+          "expr": "sum by(path) (rate(http_request_duration_count{job=\"image-renderer\"}[$__rate_interval]))",
           "legendFormat": "{{path}}",
           "range": true,
           "refId": "A"
@@ -414,7 +414,7 @@
             "uid": "${prom}"
           },
           "editorMode": "code",
-          "expr": "sum by(path, status_code) (increase(http_request_duration_count{job=\"image-renderer\"}[$__rate_interval]))",
+          "expr": "sum by(path, status_code) (rate(http_request_duration_count{job=\"image-renderer\"}[$__rate_interval]))",
           "legendFormat": "{{path}}: {{status_code}}",
           "range": true,
           "refId": "A"
@@ -686,6 +686,276 @@
       ],
       "title": "Service HTTP panicking requests rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 8,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "s"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.2.0-17567790421",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom}"
+          },
+          "editorMode": "code",
+          "expr": "max(histogram_quantile(0.95, browser_get_version_duration_bucket{job=\"image-renderer\", unit=\"seconds\"}))",
+          "legendFormat": "BrowserService.GetVersion",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Browser GetVersion durations (p95)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "s"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.2.0-17567790421",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom}"
+          },
+          "editorMode": "code",
+          "expr": "max(histogram_quantile(0.95, browser_render_duration_bucket{job=\"image-renderer\", unit=\"seconds\"}))",
+          "legendFormat": "BrowserService.Render",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom}"
+          },
+          "editorMode": "code",
+          "expr": "max(histogram_quantile(0.95, browser_render_csv_duration_bucket{job=\"image-renderer\", unit=\"seconds\"}))",
+          "hide": false,
+          "legendFormat": "BrowserService.RenderCSV",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom}"
+          },
+          "editorMode": "code",
+          "expr": "max(histogram_quantile(0.95, browser_get_version_duration_bucket{job=\"image-renderer\", unit=\"seconds\"}))",
+          "hide": false,
+          "legendFormat": "BrowserService.GetVersion",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "BrowserService durations (p95)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 10,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "s"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.2.0-17567790421",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom}"
+          },
+          "editorMode": "code",
+          "expr": "max by(action) (histogram_quantile(0.95, browser_action_duration_bucket{job=\"image-renderer\", unit=\"seconds\"}))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Browser Render action durations (p95)",
+      "type": "heatmap"
     }
   ],
   "preload": false,
@@ -731,5 +1001,5 @@
   "timezone": "browser",
   "title": "grafana-image-renderer",
   "uid": "grafana-image-renderer",
-  "version": 12
+  "version": 13
 }

--- a/devenv/docker/go-build/docker-compose.yaml
+++ b/devenv/docker/go-build/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
     command:
       - server
       - --tracing-endpoint=http://tempo:4318/v1/traces
+      - --log-level=debug
     ports:
       - 8081:8081
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/unidoc/unipdf/v4 v4.2.0
 	github.com/urfave/cli-altsrc/v3 v3.0.1
 	github.com/urfave/cli/v3 v3.4.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
@@ -81,7 +82,6 @@ require (
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	golang.org/x/crypto v0.41.0 // indirect

--- a/pkg/api/middleware/recovery.go
+++ b/pkg/api/middleware/recovery.go
@@ -31,5 +31,6 @@ func Recovery(h http.Handler) http.Handler {
 			}
 		}()
 		h.ServeHTTP(w, r)
+		span.SetStatus(codes.Ok, "no panic")
 	})
 }

--- a/pkg/api/middleware/tracing.go
+++ b/pkg/api/middleware/tracing.go
@@ -3,47 +3,36 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"net/url"
-	"sync"
 
 	"github.com/grafana/grafana-image-renderer/pkg/traces"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
 func Tracing(h http.Handler) http.Handler {
+	// We want the traceparent to return back to the requester, so they know what to look up (or what to share with support).
+	h = returningTrace(h)
+	// otelhttp.NewHandler adds some trace info and starts an http-request span.
+	// It costs a few microseconds, but we can spare that.
+	h = otelhttp.NewHandler(h, "http-request")
+	// Finally, we want to use the same trace as the requester does.
+	return propagatingTrace(h)
+}
+
+func propagatingTrace(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: Read traceparent header
+		wireContext := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		r = r.WithContext(wireContext)
+		h.ServeHTTP(w, r)
+	})
+}
 
-		sanitizedURL := *r.URL
-		if sanitizedURL.User != nil {
-			sanitizedURL.User = url.User(sanitizedURL.User.Username())
-		}
-		if sanitizedURL.Query().Has("renderKey") {
-			q := sanitizedURL.Query()
-			q.Set("renderKey", "<REDACTED>")
-			sanitizedURL.RawQuery = q.Encode()
-		}
-
-		tracer := tracer(r.Context())
-		ctx, span := tracer.Start(r.Context(), "HTTP request",
-			trace.WithAttributes(
-				attribute.String("http.method", r.Method),
-				attribute.String("http.url", sanitizedURL.String()),
-				attribute.String("http.user_agent", r.UserAgent()),
-			))
-		defer span.End()
-		r = r.WithContext(ctx)
-
-		recorder := &statusRecordingResponseWriter{rw: w}
-		h.ServeHTTP(recorder, r)
-		span.SetAttributes(attribute.Int("http.status_code", recorder.status))
-		if recorder.status >= 400 {
-			span.SetStatus(codes.Error, http.StatusText(recorder.status))
-		} else {
-			span.SetStatus(codes.Ok, http.StatusText(recorder.status))
-		}
+func returningTrace(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otel.GetTextMapPropagator().Inject(r.Context(), propagation.HeaderCarrier(w.Header()))
+		h.ServeHTTP(w, r)
 	})
 }
 
@@ -60,39 +49,4 @@ func TracingFor(name string, h http.Handler) http.Handler {
 
 func tracer(ctx context.Context) trace.Tracer {
 	return traces.TracerFromContext(ctx, "github.com/grafana/grafana-image-renderer/pkg/api/middleware")
-}
-
-var (
-	_ http.ResponseWriter = (*statusRecordingResponseWriter)(nil)
-	_ http.Flusher        = (*statusRecordingResponseWriter)(nil)
-)
-
-type statusRecordingResponseWriter struct {
-	rw     http.ResponseWriter
-	once   sync.Once
-	status int
-}
-
-func (s *statusRecordingResponseWriter) Header() http.Header {
-	return s.rw.Header()
-}
-
-func (s *statusRecordingResponseWriter) Write(b []byte) (int, error) {
-	s.once.Do(func() {
-		s.status = http.StatusOK
-	})
-	return s.rw.Write(b)
-}
-
-func (s *statusRecordingResponseWriter) WriteHeader(statusCode int) {
-	s.once.Do(func() {
-		s.status = statusCode
-	})
-	s.rw.WriteHeader(statusCode)
-}
-
-func (s *statusRecordingResponseWriter) Flush() {
-	if flusher, ok := s.rw.(http.Flusher); ok {
-		flusher.Flush()
-	}
 }

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/grafana/grafana-image-renderer/pkg/api"
 	"github.com/grafana/grafana-image-renderer/pkg/api/middleware"
+	"github.com/grafana/grafana-image-renderer/pkg/service"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 )
@@ -22,6 +23,11 @@ func NewRegistry() *prometheus.Registry {
 
 		api.MetricRenderDuration,
 		api.MetricRenderCSVDuration,
+
+		service.MetricBrowserActionDuration,
+		service.MetricBrowserGetVersionDuration,
+		service.MetricBrowserRenderCSVDuration,
+		service.MetricBrowserRenderDuration,
 	)
 	return registry
 }


### PR DESCRIPTION
This implements a few more things in o11y:
* Metrics for browser steps
* Metrics for browser renderer functions
* Propagation of traceparent to browser requests
* Incoming propagation support when we're called with a traceparent
* Removes sensitive info from the traced URLs
* Traces outgoing browser requests

<img width="2039" height="1807" alt="image" src="https://github.com/user-attachments/assets/6f84e71b-4183-40f1-984e-40e44482dabe" />
