### PR TITLE
ci: build Go images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -69,11 +69,23 @@ jobs:
         include:
           - runs-on: ubuntu-24.04
             arch: amd64
+            dockerfile: Dockerfile
+            suffix: ''
           - runs-on: ubuntu-24.04-arm
             arch: arm64
+            dockerfile: Dockerfile
+            suffix: ''
+          - runs-on: ubuntu-24.04
+            arch: amd64
+            dockerfile: go.Dockerfile
+            suffix: '-golang'
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
+            dockerfile: go.Dockerfile
+            suffix: '-golang'
 
     needs: tag
-    name: Build image for ${{ matrix.arch }}
+    name: Build ${{ matrix.dockerfile }} image for ${{ matrix.arch }}
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read # required to read the repository contents
@@ -101,16 +113,16 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_STEP_LOG_MAX_SIZE: -1
           BUILDKIT_STEP_LOG_MAX_SPEED: -1
-          TAG: ${{ needs.tag.outputs.tag }}-${{ matrix.arch }}
-        run: docker build . -t "$TAG"
+          TAG: ${{ needs.tag.outputs.tag }}${{ matrix.suffix }}-${{ matrix.arch }}
+        run: docker build . -t "$TAG" -f ${{ matrix.dockerfile }}
       - name: docker push
         env:
-          TAG: ${{ needs.tag.outputs.tag }}-${{ matrix.arch }}
+          TAG: ${{ needs.tag.outputs.tag }}${{ matrix.suffix }}-${{ matrix.arch }}
         run: docker push "$TAG"
       - name: Get digest
         id: digest
         env:
-          TAG: ${{ needs.tag.outputs.tag }}-${{ matrix.arch }}
+          TAG: ${{ needs.tag.outputs.tag }}${{ matrix.suffix }}-${{ matrix.arch }}
         run: |
           set -euo pipefail
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$TAG" | cut -d@ -f2)
@@ -141,13 +153,15 @@ jobs:
         if: needs.tag.outputs.registry == 'docker.io'
         uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1
 
-      - name: Create and push manifest
+      - name: Create and push manifests
         env:
           TAG: ${{ needs.tag.outputs.tag }}
         run: |
           set -euo pipefail
           docker manifest create "$TAG" "$TAG"-amd64 "$TAG"-arm64
+          docker manifest create "$TAG"-golang "$TAG"-golang-amd64 "$TAG"-golang-arm64
           docker manifest push "$TAG"
+          docker manifest push "$TAG"-golang
       - name: Create and push :latest manifest
         if: github.event_name == 'push' && github.ref_type == 'tag'
         env:
@@ -169,7 +183,10 @@ jobs:
             You can pull it using:
 
             ```bash
+            # For the Node.js server:
             docker pull ${{ needs.tag.outputs.tag }}
+            # For the Go server:
+            docker pull ${{ needs.tag.outputs.tag }}-golang
             ```
 
             > [!WARNING]


### PR DESCRIPTION
Now, we'll get the images out for testing and dev deployment.

```shell
$ docker run --rm -it ghcr.io/grafana/grafana-image-renderer:dev-pull-778-7cdef5418923927971c3b32c42c20e0a5d9beca0-golang
Unable to find image 'ghcr.io/grafana/grafana-image-renderer:dev-pull-778-7cdef5418923927971c3b32c42c20e0a5d9beca0-golang' locally
dev-pull-778-7cdef5418923927971c3b32c42c20e0a5d9beca0-golang: Pulling from grafana/grafana-image-renderer
259db2ee6b87: Pull complete
bfb59b82a9b6: Pull complete
56ce5a7a0a8c: Pull complete
e1089d61b200: Pull complete
0f8b424aa0b9: Pull complete
7c12895b777b: Pull complete
3214acf345c0: Pull complete
5664b15f108b: Pull complete
1069fc2daed1: Pull complete
4aa0ea1413d3: Pull complete
da7816fa955e: Pull complete
ddf74a63f7d8: Pull complete
b3c9f64f6f17: Pull complete
3c47353ed960: Pull complete
122f93426eb3: Pull complete
9feac7345a92: Pull complete
dcea7283c357: Pull complete
4f4fb700ef54: Pull complete
a495c2f38232: Pull complete
5f8827c47bb8: Pull complete
062d727ddb78: Pull complete
763f63740a97: Pull complete
Digest: sha256:4fd8fa8bc6a27d9da659948ff6052632619ce72a554c5500d6e67caef09bfcb7
Status: Downloaded newer image for ghcr.io/grafana/grafana-image-renderer:dev-pull-778-7cdef5418923927971c3b32c42c20e0a5d9beca0-golang

time=2025-09-12T12:00:29.417Z level=INFO source=/src/pkg/traces/traces.go:136 msg="no tracing endpoint configured, not setting up tracing"
time=2025-09-12T12:00:29.417Z level=INFO source=/src/pkg/api/server.go:38 msg="serving HTTP traffic" addr=:8081
```