### PR TITLE
ci: use self-hosted runners for Docker

### DIFF
--- a/.github/workflows/docker-scan.yaml
+++ b/.github/workflows/docker-scan.yaml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         file: [Dockerfile, go.Dockerfile]
-        # TODO: Use self-hosted runners when available.
-        runs-on: [github-hosted-ubuntu-arm64-large, github-hosted-ubuntu-x64-large]
+        runs-on: [ubuntu-x64, ubuntu-arm64]
 
     name: grype scanning (${{ matrix.runs-on }}, ${{ matrix.file }})
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/docker-scan.yaml
+++ b/.github/workflows/docker-scan.yaml
@@ -61,8 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         file: [Dockerfile, go.Dockerfile]
-        # TODO: Use self-hosted runners when available.
-        runs-on: [github-hosted-ubuntu-arm64-large, github-hosted-ubuntu-x64-large]
+        runs-on: [ubuntu-x64, ubuntu-arm64]
 
     name: trivy scanning (${{ matrix.runs-on }}, ${{ matrix.file }})
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         file: [Dockerfile, go.Dockerfile]
-        # TODO: Use self-hosted runners when available.
-        runs-on: [github-hosted-ubuntu-arm64-large, github-hosted-ubuntu-x64-large]
+        runs-on: [ubuntu-x64, ubuntu-arm64]
 
     name: acceptance tests (${{ matrix.runs-on }}, ${{ matrix.file }})
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -67,19 +67,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-x64
             arch: amd64
             dockerfile: Dockerfile
             suffix: ''
-          - runs-on: ubuntu-24.04-arm
+          - runs-on: ubuntu-arm64
             arch: arm64
             dockerfile: Dockerfile
             suffix: ''
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-x64
             arch: amd64
             dockerfile: go.Dockerfile
             suffix: '-golang'
-          - runs-on: ubuntu-24.04-arm
+          - runs-on: ubuntu-arm64
             arch: arm64
             dockerfile: go.Dockerfile
             suffix: '-golang'


### PR DESCRIPTION
Our docker builds are relatively slow, so using our own runners with faster CPUs helps. Wherever we replace larger-than-default GH runners, we also save money.