### PR TITLE
fix: parse browser flags properly

### DIFF
--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -447,11 +447,13 @@ func (s *BrowserService) createAllocatorOptions(renderingOptions *renderingOptio
 	opts = append(opts, chromedp.WindowSize(renderingOptions.viewportWidth, renderingOptions.viewportHeight))
 	for _, arg := range s.args {
 		arg = strings.TrimPrefix(arg, "--")
-		equals := strings.Index(arg, "=")
-		if equals == -1 {
-			opts = append(opts, chromedp.Flag(arg, ""))
+		key, value, hadEquals := strings.Cut(arg, "=")
+		if !hadEquals || value == "true" {
+			opts = append(opts, chromedp.Flag(key, true))
+		} else if value == "false" {
+			opts = append(opts, chromedp.Flag(key, false))
 		} else {
-			opts = append(opts, chromedp.Flag(arg[:equals], arg[equals+1:]))
+			opts = append(opts, chromedp.Flag(key, value))
 		}
 	}
 


### PR DESCRIPTION
When passing in a boolean flag, set it to true; if it's false, set it to a real false, not the string.