### PR TITLE
fix(go): propagate traceparent without respecting CORS

### DIFF
--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,7 +20,9 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/browser"
+	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
@@ -233,6 +236,7 @@ func (s *BrowserService) Render(ctx context.Context, url string, printer Printer
 	fileChan := make(chan []byte, 1) // buffered: we don't want the browser to stick around while we try to export this value.
 	actions := []chromedp.Action{
 		tracingAction("network.Enable", network.Enable()),
+		tracingAction("fetch.Enable", fetch.Enable()), // required by handleNetworkEvents
 		tracingAction("SetPageScaleFactor", emulation.SetPageScaleFactor(cfg.PageScaleFactor)),
 		tracingAction("EmulateViewport", chromedp.EmulateViewport(int64(cfg.MinWidth), int64(cfg.MinHeight), orientation)),
 		setHeaders(browserCtx, cfg.Headers),
@@ -392,6 +396,34 @@ func (s *BrowserService) handleNetworkEvents(browserCtx context.Context) {
 		// See the docs of ListenTarget for more.
 
 		switch e := ev.(type) {
+		case *fetch.EventRequestPaused:
+			go func() {
+				if sc := trace.SpanFromContext(browserCtx); sc != nil && sc.IsRecording() {
+					otel.GetTextMapPropagator().Inject(browserCtx, networkHeadersCarrier(e.Request.Headers))
+				}
+
+				hdrs := make([]*fetch.HeaderEntry, 0, len(e.Request.Headers))
+				for k, v := range e.Request.Headers {
+					hdrs = append(hdrs, &fetch.HeaderEntry{Name: k, Value: fmt.Sprintf("%v", v)})
+				}
+
+				ctx, span := tracer.Start(browserCtx, "fetch.ContinueRequest",
+					trace.WithAttributes(
+						attribute.String("requestID", string(e.RequestID)),
+						attribute.String("url", e.Request.URL),
+						attribute.String("method", e.Request.Method),
+						attribute.Int("headers", len(e.Request.Headers)),
+					))
+				defer span.End()
+				cdpCtx := chromedp.FromContext(browserCtx)
+				ctx = cdp.WithExecutor(ctx, cdpCtx.Target)
+
+				if err := fetch.ContinueRequest(e.RequestID).WithHeaders(hdrs).Do(ctx); err != nil {
+					span.SetStatus(codes.Error, err.Error())
+					slog.DebugContext(ctx, "failed to continue request", "requestID", e.RequestID, "error", err)
+				}
+			}()
+
 		case *network.EventRequestWillBeSent:
 			mu.Lock()
 			defer mu.Unlock()
@@ -414,17 +446,20 @@ func (s *BrowserService) handleNetworkEvents(browserCtx context.Context) {
 			if !ok {
 				return
 			}
+			statusText := e.Response.StatusText
+			if statusText == "" {
+				statusText = http.StatusText(int(e.Response.Status))
+			}
 			span.SetAttributes(
 				attribute.Int("status", int(e.Response.Status)),
-				attribute.String("statusText", e.Response.StatusText),
+				attribute.String("statusText", statusText),
 				attribute.String("mimeType", e.Response.MimeType),
 				attribute.String("protocol", e.Response.Protocol),
-				attribute.String("contentType", fmt.Sprintf("%v", e.Response.Headers["Content-Type"])),
 			)
 			if e.Response.Status >= 400 {
-				span.SetStatus(codes.Error, e.Response.StatusText)
+				span.SetStatus(codes.Error, fmt.Sprintf("%d %s", e.Response.Status, statusText))
 			} else {
-				span.SetStatus(codes.Ok, e.Response.StatusText)
+				span.SetStatus(codes.Ok, fmt.Sprintf("%d %s", e.Response.Status, statusText))
 			}
 			span.End(trace.WithTimestamp(e.Timestamp.Time()))
 			delete(requests, e.RequestID) // no point keeping it around anymore.
@@ -751,13 +786,6 @@ func NewPNGPrinter(opts ...PNGPrinterOption) (*pngPrinter, error) {
 }
 
 func setHeaders(browserCtx context.Context, headers network.Headers) chromedp.Action {
-	if sc := trace.SpanFromContext(browserCtx); sc != nil && sc.IsRecording() {
-		if headers == nil {
-			headers = make(network.Headers)
-		}
-		otel.GetTextMapPropagator().Inject(browserCtx, networkHeadersCarrier(headers))
-	}
-
 	return chromedp.ActionFunc(func(ctx context.Context) error {
 		tracer := tracer(ctx)
 		ctx, span := tracer.Start(ctx, "setHeaders",


### PR DESCRIPTION
CORS headers ensure that we cannot always send `traceparent` via the browser, according to the browser. However, we want to always send the header regardless of CORS, such that the receiving service can decide whether it wants to care about it.

As such, we should use the `Fetch` APIs, which let us arbitrarily change the outgoing requests without any CORS restrictions.

Thanks to Josh for helping me figure this out!