### PR TITLE
feat: release v4.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.19 (2025-10-14)
+
+This release does not change the current Grafana Image Renderer, it is only issued to release new tags of the `-golang` variants for further testing.
+
 ## 4.0.18 (2025-10-13)
 
 - Docker: Update Chromium to 141.0.7390.65 (CVE-2025-11458, CVE-2025-11460, CVE-2025-11211), [#809](https://github.com/grafana/grafana-image-renderer/pull/809), [Proximyst](https://github.com/Proximyst)

--- a/plugin.json
+++ b/plugin.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/grafana/grafana-image-renderer/blob/master/LICENSE"
       }
     ],
-    "version": "4.0.18",
-    "updated": "2025-10-13"
+    "version": "4.0.19",
+    "updated": "2025-10-14"
   },
   "dependencies": {
     "grafanaDependency": ">=11.3.8"


### PR DESCRIPTION
We need stable tags we can depend on for deployment to Ops.