### PR TITLE
CI: Disable dev CD

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -196,7 +196,8 @@ jobs:
 # Workflow: https://argo-workflows.grafana.net/workflow-templates/render-service-cd/auto-deploy-dev
   cd-auto-deploy-dev:
     name: Deploy to dev
-    if: startsWith(github.ref, 'refs/tags/v')
+    # disabled while we test the golang image
+    if: false && startsWith(github.ref, 'refs/tags/v')
     needs: [tag, build]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
We don't want the image to be overwritten automatically while we test the golang images.

before enabling, I reckon we might also want to ensure it doesn't cause git conflicts on the prod CD.