### PR TITLE
feat(go): add metric for active browser instances

### DIFF
--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -28,6 +28,7 @@ func NewRegistry() *prometheus.Registry {
 		service.MetricBrowserGetVersionDuration,
 		service.MetricBrowserRenderCSVDuration,
 		service.MetricBrowserRenderDuration,
+		service.MetricBrowserInstancesActive,
 	)
 	return registry
 }

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -42,6 +42,10 @@ var (
 		},
 	})
 
+	MetricBrowserInstancesActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "browser_instances_active",
+		Help: "How many browser instances are currently launched at any given time?",
+	})
 	MetricBrowserRenderDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "browser_render_duration",
 		ConstLabels: prometheus.Labels{
@@ -250,6 +254,8 @@ func (s *BrowserService) Render(ctx context.Context, url string, printer Printer
 		observingAction("printer.action", printer.action(fileChan, cfg)),
 	}
 	span.AddEvent("actions created")
+	MetricBrowserInstancesActive.Inc()
+	defer MetricBrowserInstancesActive.Dec()
 	if err := chromedp.Run(browserCtx, actions...); err != nil {
 		return nil, "text/plain", fmt.Errorf("failed to run browser: %w", err)
 	}
@@ -324,6 +330,8 @@ func (s *BrowserService) RenderCSV(ctx context.Context, url, renderKey, domain, 
 		observingAction("SetDownloadBehavior", browser.SetDownloadBehavior(browser.SetDownloadBehaviorBehaviorAllow).WithDownloadPath(tmpDir)),
 		observingAction("Navigate", chromedp.Navigate(url)),
 	}
+	MetricBrowserInstancesActive.Inc()
+	defer MetricBrowserInstancesActive.Dec()
 	if err := chromedp.Run(browserCtx, actions...); err != nil {
 		return nil, fmt.Errorf("failed to run browser: %w", err)
 	}


### PR DESCRIPTION
It's handy to know how many browsers are up and running at any given time.