### PR TITLE
fix: upgrade in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - This only removes the headers. The CVEs are not actually exploitable in the image.
   - This work is done to clean up CVE results in tools like Trivy and Grype, that scan vulnerabilities in images.
 - fix: remove all unnecessary headers and unnecessary packages (CVE-2017-13716, CVE-2018-20673, CVE-2018-20712, CVE-2018-9996, CVE-2020-36325, CVE-2021-32256, CVE-2025-11081, CVE-2025-11082, CVE-2025-11083, CVE-2025-11411, CVE-2025-11412, CVE-2025-11413, CVE-2025-11414, CVE-2025-1147, CVE-2025-1148, CVE-2025-1149, CVE-2025-11494, CVE-2025-11495, CVE-2025-1150, CVE-2025-1151, CVE-2025-1152, CVE-2025-1153, CVE-2025-1176, CVE-2025-1178, CVE-2025-1180, CVE-2025-1181, CVE-2025-1182, CVE-2025-11839, CVE-2025-11840, CVE-2025-3198, CVE-2025-5244, CVE-2025-5245, CVE-2025-7545, CVE-2025-7546, CVE-2025-8225), [#837](https://github.com/grafana/grafana-image-renderer/pull/837), [Proximyst](https://github.com/Proximyst)
+- fix: upgrade in Dockerfile (CVE-2024-13978, CVE-2025-8961, CVE-2025-9165, CVE-2025-9900)
 
 ## 4.1.3 (2025-10-29)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2025-10-30' && apt-get update
+RUN echo 'cachebuster 2025-10-30' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \

--- a/go.Dockerfile
+++ b/go.Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/go.Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2025-10-30' && apt-get update
+RUN echo 'cachebuster 2025-10-30' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \


### PR DESCRIPTION
Upgrades all existing dependencies in the Dockerfile.
This does not upgrade the Node version, to be clear, as that isn't installed via Debian.

Fixes: CVE-2024-13978
Fixes: CVE-2025-8961
Fixes: CVE-2025-9165
Fixes: CVE-2025-9900