### PR TITLE
feat(go): change in-flight metric to only count expensive requests

### DIFF
--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -12,7 +12,7 @@ import (
 var (
 	MetricRequestsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "http_requests_in_flight",
-		Help: "How many requests are in flight?",
+		Help: "How many expensive requests are in flight?",
 	})
 	MetricRequestDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "http_request_duration",
@@ -39,11 +39,22 @@ func RequestMetrics(h http.Handler) http.Handler {
 		r = r.WithContext(ctx)
 
 		now := time.Now()
-		MetricRequestsInFlight.Inc()
 		recorder := &statusRecordingResponseWriter{rw: w}
 		h.ServeHTTP(recorder, r)
-		MetricRequestsInFlight.Dec()
 		MetricRequestDurations.WithLabelValues(r.Method, r.Pattern, strconv.Itoa(recorder.status)).Observe(time.Since(now).Seconds())
+	})
+}
+
+func InFlightMetrics(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tracer := tracer(r.Context())
+		ctx, span := tracer.Start(r.Context(), "InFlightMetrics")
+		defer span.End()
+		r = r.WithContext(ctx)
+
+		MetricRequestsInFlight.Inc()
+		defer MetricRequestsInFlight.Dec() // defer to run despite panics
+		h.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
Only expensive requests are now counted when we count in-flight requests. This means `/metrics`, `/`, etc. are not counted, but `/render` and `/render/csv` are.