### PR TITLE
feat: update Chromium to 142.0.7444.59

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build \
 FROM debian:13@sha256:72547dd722cd005a8c2aa2079af9ca0ee93aad8e589689135feaed60b0a8c08d AS output_image
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
-LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/go.Dockerfile"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
 RUN echo 'cachebuster 2025-11-03' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests


### PR DESCRIPTION
This will be minted to v5.0.3.

Fixes: CVE-2025-12036
Fixes: CVE-2025-12428
Fixes: CVE-2025-12429
Fixes: CVE-2025-12430
Fixes: CVE-2025-12431
Fixes: CVE-2025-12432
Fixes: CVE-2025-12433
Fixes: CVE-2025-12434
Fixes: CVE-2025-12435
Fixes: CVE-2025-12436
Fixes: CVE-2025-12437
Fixes: CVE-2025-12438
Fixes: CVE-2025-12439
Fixes: CVE-2025-12440
Fixes: CVE-2025-12441
Fixes: CVE-2025-12443
Fixes: CVE-2025-12444
Fixes: CVE-2025-12445
Fixes: CVE-2025-12446
Fixes: CVE-2025-12447