### PR TITLE
Add next version docs publishing workflow

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,6 +1,10 @@
-name: publish-technical-documentation-next
+name: Documentation publication
 
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:


### PR DESCRIPTION
Add `publish-technical-documentation-next.yml` workflow to sync `docs/sources` to `content/docs/grafana-image-renderer/next` for next-version documentation.

On the website side, I'll open up the PR that mounts the docs into the Grafana documentation. These docs won't go live until we merge that website PR.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C07R2REUULS/p1762415855037939?thread_ts=1762415855.037939&cid=C07R2REUULS)

<a href="https://cursor.com/background-agent?bcId=bc-32d16a3f-d343-4a0f-809a-8a20b364c31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32d16a3f-d343-4a0f-809a-8a20b364c31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

