### PR TITLE
Browser: Return 408 status code on readiness timeout

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -237,7 +237,8 @@ func HandleGetRender(browser *service.BrowserService) http.Handler {
 			span.SetStatus(codes.Error, "rendering failed")
 			span.RecordError(err)
 			if errors.Is(err, context.DeadlineExceeded) ||
-				errors.Is(err, context.Canceled) {
+				errors.Is(err, context.Canceled) ||
+				errors.Is(err, service.ErrBrowserReadinessTimeout) {
 				http.Error(w, "Request timed out", http.StatusRequestTimeout)
 				return
 			} else if errors.Is(err, service.ErrInvalidBrowserOption) {

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -77,7 +77,10 @@ var (
 	}, []string{"mime_type"})
 )
 
-var ErrInvalidBrowserOption = errors.New("invalid browser option")
+var (
+	ErrInvalidBrowserOption    = errors.New("invalid browser option")
+	ErrBrowserReadinessTimeout = errors.New("timed out waiting for readiness")
+)
 
 type BrowserService struct {
 	cfg       config.BrowserConfig
@@ -1001,8 +1004,8 @@ func waitForReady(browserCtx context.Context, cfg config.BrowserConfig) chromedp
 				span.SetStatus(codes.Error, "context completed before readiness detected")
 				return ctx.Err()
 			case <-readinessTimeout:
-				span.SetStatus(codes.Error, "timed out waiting for readiness")
-				return fmt.Errorf("timed out waiting for readiness")
+				span.SetStatus(codes.Error, ErrBrowserReadinessTimeout.Error())
+				return ErrBrowserReadinessTimeout
 
 			case <-time.After(cfg.ReadinessIterationInterval):
 				// Continue with the rest of the code; this is waiting for the next time we can do work.


### PR DESCRIPTION
Previously, if the browser readiness timeout was hit, it would not be caught and return a generic 500. Instead, we now return a proper 408.

Fixes #861