### PR TITLE
docs: update monitoring heading to reflect current title in grafana docs

### DIFF
--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -45,7 +45,7 @@ service. With our Docker images, this is `/home/nonroot/` by default.
 
 The file names must be one of `config.json`, `config.yaml`, or `config.yml`.
 
-## Monitoring
+## Monitor the image renderer
 
 You can monitor the service via Prometheus or
 [Mimir](https://grafana.com/oss/mimir) and any OpenTelemetry-compatible Tracing


### PR DESCRIPTION
Updated `docs/sources/troubleshooting.md` to change the "monitoring" section heading to "Monitor the image renderer". This keeps the language aligned with current use in the `grafana/grafana` repository and makes it more action-orineted 