### PR TITLE
docs: alias monitoring to troubleshooting

### DIFF
--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../image-rendering/troubleshooting/
+  - monitoring
 description: Image rendering troubleshooting
 keywords:
   - grafana


### PR DESCRIPTION
This adds an alias such that `/docs/grafana/latest/setup-grafana/image-rendering/monitoring/` points towards the troubleshooting page. This is required as the two pages merged.