### PR TITLE
feat(auth): emit metrics with token index

### DIFF
--- a/devenv/docker/go-build/docker-compose.yaml
+++ b/devenv/docker/go-build/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       TRACING_ENDPOINT: http://tempo:4318/v1/traces
       LOG_LEVEL: debug
+      AUTH_TOKEN: one,two,three,four,five
     command:
       - server
       # 1 GiB
@@ -91,6 +92,7 @@ services:
     environment:
       GF_RENDERING_SERVER_URL: http://renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
+      GF_RENDERING_RENDERER_TOKEN: three
       GF_TRACING_OPENTELEMETRY_OTLP_ADDRESS: tempo:4317
       GF_INSTALL_PLUGINS: https://storage.googleapis.com/integration-artifacts/grafana-exploretraces-app/grafana-exploretraces-app-latest.zip;grafana-traces-app
       GF_LOG_FILTERS: rendering:debug

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -1,16 +1,23 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var MetricAuthenticatedRequestAttempt = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name: "http_authenticated_request_attempts_total",
-	Help: "Counts the attempts of authenticated requests",
-}, []string{"result"})
+var (
+	MetricAuthenticatedRequestAttempt = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_authenticated_request_attempts_total",
+		Help: "Counts the attempts of authenticated requests",
+	}, []string{"result"})
+	MetricAuthenticationTokenUsage = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_authentication_token_usage_total",
+		Help: "Counts how many times each authentication token is used",
+	}, []string{"token_index"})
+)
 
 // RequireAuthToken demands the request has a valid X-Auth-Token header attached to it.
 func RequireAuthToken(h http.Handler, expectedTokens ...string) http.Handler {
@@ -25,8 +32,10 @@ func RequireAuthToken(h http.Handler, expectedTokens ...string) http.Handler {
 			MetricAuthenticatedRequestAttempt.WithLabelValues("missing-header").Inc()
 			return
 		}
-		if slices.Contains(expectedTokens, token) {
+		tokenIdx := slices.Index(expectedTokens, token)
+		if tokenIdx != -1 {
 			MetricAuthenticatedRequestAttempt.WithLabelValues("valid-token").Inc()
+			MetricAuthenticationTokenUsage.WithLabelValues(fmt.Sprintf("%d", tokenIdx)).Inc()
 			span.End() // we don't want to track the next middleware in this span
 			h.ServeHTTP(w, r)
 			return

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -16,6 +16,7 @@ func NewRegistry() *prometheus.Registry {
 		collectors.NewBuildInfoCollector(),
 
 		middleware.MetricAuthenticatedRequestAttempt,
+		middleware.MetricAuthenticationTokenUsage,
 		middleware.MetricRateLimiterSlots,
 		middleware.MetricRateLimiterRequests,
 		middleware.MetricRequestsInFlight,


### PR DESCRIPTION
This is useful to ascertain whether migrating tokens is successful, and whether any clients are still using any old tokens.