### PR TITLE
Actions: Bump GitHub-related actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       GOARCH: ${{ matrix.GOARCH }}
       SUFFIX: ${{ matrix.SUFFIX || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -47,7 +47,7 @@ jobs:
           cache: false
       - name: go build
         run: go build -o grafana-image-renderer-"$GOOS"-"$GOARCH""$SUFFIX" -buildvcs -ldflags '-s -w' .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: grafana-image-renderer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.SUFFIX || '' }}
           path: grafana-image-renderer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.SUFFIX || '' }}
@@ -129,7 +129,7 @@ jobs:
         if: needs.tag.outputs.registry == 'docker.io'
         uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -222,7 +222,7 @@ jobs:
       contents: write # to create the release
       packages: read # to read the package information
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           merge-multiple: true
           path: bins/

--- a/.github/workflows/docker-scan.yaml
+++ b/.github/workflows/docker-scan.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read # clone the repository
       security-events: write # upload SARIF results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -66,7 +66,7 @@ jobs:
       contents: read # clone the repository
       security-events: write # upload SARIF results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read # clone the repository
       id-token: write # required to read secrets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation@9aed4f7c5b3caa1b58d72ee39232333407d4acbf # publish-technical-documentation/v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read # clone the repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read # clone the repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read # clone the repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: read # clone the repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6


### PR DESCRIPTION
Updates:
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/checkout@v5` -> `actions/checkout@v6`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v5`
- `actions/download-artifact@v4` -> `actions/download-artifact@v5`

Fixes GHSA-cxww-7g56-2vh6