### PR TITLE
Build: Statically compile binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
       GOOS: ${{ matrix.GOOS }}
       GOARCH: ${{ matrix.GOARCH }}
       SUFFIX: ${{ matrix.SUFFIX || '' }}
+      CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,7 +47,7 @@ jobs:
           go-version-file: go.mod
           cache: false
       - name: go build
-        run: go build -o grafana-image-renderer-"$GOOS"-"$GOARCH""$SUFFIX" -buildvcs -ldflags '-s -w' .
+        run: go build -o grafana-image-renderer-"$GOOS"-"$GOARCH""$SUFFIX" -buildvcs -ldflags '-s -w -extldflags "-static"' .
       - uses: actions/upload-artifact@v5
         with:
           name: grafana-image-renderer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.SUFFIX || '' }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OUT_DIR = dist
 BINARY ?= $(OUT_DIR)/grafana-image-renderer
+GO_BUILD_FLAGS = -buildvcs -ldflags '-s -w -extldflags "-static"'
 
 .PHONY: check
 check: lint test
@@ -25,16 +26,16 @@ fix:
 
 .PHONY: build
 build: $(OUT_DIR)
-	go build -buildvcs -o $(BINARY) .
+	CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -o $(BINARY) .
 
 .PHONY: build-all
 build-all: build $(OUT_DIR)
-	GOOS=linux GOARCH=amd64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-linux-amd64 .
-	GOOS=linux GOARCH=arm64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-linux-arm64 .
-	GOOS=darwin GOARCH=amd64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-darwin-amd64 .
-	GOOS=darwin GOARCH=arm64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-darwin-arm64 .
-	GOOS=windows GOARCH=amd64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-windows-amd64.exe .
-	GOOS=windows GOARCH=arm64 go build -buildvcs -o $(OUT_DIR)/grafana-image-renderer-windows-arm64.exe .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-linux-amd64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-linux-arm64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-darwin-amd64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-darwin-arm64 .
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-windows-amd64.exe .
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(OUT_DIR)/grafana-image-renderer-windows-arm64.exe .
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
We are already building statically in the Docker image, so we can do the same with the binaries we release, so it doesn't depend on dynamic shared libraries.