### PR TITLE
Add config for waiting for multiple successful cycles until rendering

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -322,8 +322,8 @@ type BrowserConfig struct {
 	// ReadinessTimeout is the maximum time to wait for the web-page to become ready (i.e. no longer loading anything).
 	ReadinessTimeout           time.Duration
 	ReadinessIterationInterval time.Duration
-	// ReadinessWaitForNCycles is the number of readiness checks that must pass consecutively before considering the page ready. This handles the case where queries drop to 0 briefly before incrementing again.
-	ReadinessWaitForNCycles int
+	// ReadinessWaitForNQueryCycles is the number of readiness checks that must pass consecutively before considering the page ready. This handles the case where queries drop to 0 briefly before incrementing again.
+	ReadinessWaitForNQueryCycles int
 	// ReadinessPriorWait is the time to wait before checking for how ready the page is.
 	// This lets you force the webpage to take a beat and just do its thing before the service starts looking for whether it's time to render anything.
 	ReadinessPriorWait              time.Duration
@@ -450,12 +450,12 @@ func BrowserFlags() []cli.Flag {
 			},
 		},
 		&cli.IntFlag{
-			Name:  "browser.readiness.wait-for-n-cycles",
+			Name:  "browser.readiness.wait-for-n-query-cycles",
 			Usage: "The number of readiness checks that must pass consecutively before considering the page ready.",
 			Value: 1,
 			Validator: func(i int) error {
 				if i < 1 {
-					return fmt.Errorf("browser readiness wait-for-n-cycles must be at least 1 (got %d)", i)
+					return fmt.Errorf("browser readiness wait-for-n-query-cycles must be at least 1 (got %d)", i)
 				}
 				return nil
 			},
@@ -609,7 +609,7 @@ func BrowserConfigFromCommand(c *cli.Command) (BrowserConfig, error) {
 		TimeBetweenScrolls:              c.Duration("browser.time-between-scrolls"),
 		ReadinessTimeout:                c.Duration("browser.readiness.timeout"),
 		ReadinessIterationInterval:      c.Duration("browser.readiness.iteration-interval"),
-		ReadinessWaitForNCycles:         c.Int("browser.readiness.wait-for-n-cycles"),
+		ReadinessWaitForNQueryCycles:    c.Int("browser.readiness.wait-for-n-query-cycles"),
 		ReadinessPriorWait:              c.Duration("browser.readiness.prior-wait"),
 		ReadinessDisableQueryWait:       c.Bool("browser.readiness.disable-query-wait"),
 		ReadinessFirstQueryTimeout:      c.Duration("browser.readiness.give-up-on-first-query"),

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -1035,9 +1035,9 @@ func waitForReady(browserCtx context.Context, cfg config.BrowserConfig) chromedp
 				} else if !hasSeenAnyQuery && (cfg.ReadinessFirstQueryTimeout <= 0 || time.Since(start) < cfg.ReadinessFirstQueryTimeout) {
 					span.AddEvent("no first query detected yet; giving it more time")
 					continue
-				} else if numSuccessfulCycles+1 < cfg.ReadinessWaitForNCycles {
+				} else if numSuccessfulCycles+1 < cfg.ReadinessWaitForNQueryCycles {
 					numSuccessfulCycles++
-					span.AddEvent("waiting for more successful readiness cycles", trace.WithAttributes(attribute.Int("currentCycle", numSuccessfulCycles), attribute.Int("requiredCycles", cfg.ReadinessWaitForNCycles)))
+					span.AddEvent("waiting for more successful readiness cycles", trace.WithAttributes(attribute.Int("currentCycle", numSuccessfulCycles), attribute.Int("requiredCycles", cfg.ReadinessWaitForNQueryCycles)))
 					continue // need more successful cycles
 				}
 			}


### PR DESCRIPTION
Active queries can drop down 0 before before incrementing again. If there is enough of a pause between these two events, the dashboard can be rendered before it is ready. We are seeing that on [this escalation](https://github.com/grafana/support-escalations/issues/19470), where the active queries temporarily drop to 0 for 40ms at times, causing the dashboard to render blank.

Starting out implementing this as a global setting so that we can get a fix out to customers sooner. Once we have validated it, we can change it to a request-specific config.