### PR TITLE
docs: document how wait-for-n-query-cycles works

### DIFF
--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -197,7 +197,7 @@ This is done by waiting for all of the following to complete or time out:
       By default, this timeout is disabled.
     - If there is no first query detected within the duration declared by the `--browser.readiness.give-up-on-first-query` option, the check is silently skipped.
       By default, this timeout is 3 seconds.
-    - If the `--browser.readiness.wait-for-n-query-cycles` is set to a value greater than `1`, we will wait for `N` full query cycles to succeed before proceeding.
+    - If the `--browser.readiness.wait-for-n-query-cycles` is set to a value greater than `1`, the service waits for `N` full query cycles to succeed before proceeding.
       Each query cycle is separated by the duration as declared by the `--browser.readiness.interval` option.
       If any query timeout passes during these cycles, the check is silently skipped.
   - The browser waits for all network requests to complete, unless the `--browser.readiness.disable-network-wait` option is enabled.


### PR DESCRIPTION
We got a question about this from support, and I realised we don't have it documented clearly.