### PR TITLE
Tests: Restore parallel and run in CI with better runners

### DIFF
--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-x64, ubuntu-arm64]
+        runs-on: [ubuntu-x64-xlarge, ubuntu-arm64-xlarge]
 
     name: acceptance tests (${{ matrix.runs-on }})
     runs-on: ${{ matrix.runs-on }}

--- a/pkg/api/healthz_test.go
+++ b/pkg/api/healthz_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetHealthzReturnsOK(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAuthTokenRequired(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	alwaysOK := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -27,7 +27,7 @@ func TestAuthTokenRequired(t *testing.T) {
 		"correct auth token": {Value: "correct", ExpectedStatus: http.StatusOK},
 	} {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			rec := httptest.NewRecorder()
 			middleware := middleware.RequireAuthToken(alwaysOK, "correct")

--- a/pkg/api/middleware/metrics_test.go
+++ b/pkg/api/middleware/metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMetricsMiddlewareDoesNotPanic(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	rec := httptest.NewRecorder()
 	middleware := middleware.Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/middleware/recovery_test.go
+++ b/pkg/api/middleware/recovery_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRecovery(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	panickingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic("oh no")
@@ -20,7 +20,7 @@ func TestRecovery(t *testing.T) {
 	})
 
 	t.Run("non-panicking handler returns fine", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		rec := httptest.NewRecorder()
 		middleware := middleware.Recovery(okHandler)
@@ -33,7 +33,7 @@ func TestRecovery(t *testing.T) {
 	})
 
 	t.Run("panicking handler returns error", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		rec := httptest.NewRecorder()
 		middleware := middleware.Recovery(panickingHandler)

--- a/pkg/api/middleware/tracing_test.go
+++ b/pkg/api/middleware/tracing_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTracing(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -21,7 +21,7 @@ func TestTracing(t *testing.T) {
 	mux.Handle("GET /", okHandler)
 
 	t.Run("without TracerProvider in context", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		rec := httptest.NewRecorder()
 		middleware := middleware.Recovery(mux)
@@ -32,7 +32,7 @@ func TestTracing(t *testing.T) {
 	})
 
 	t.Run("with no-op TracerProvider in context", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		tracerProvider := noop.NewTracerProvider()
 		ctx := traces.WithTracerProvider(t.Context(), tracerProvider)

--- a/pkg/api/middleware/trustedurl_test.go
+++ b/pkg/api/middleware/trustedurl_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTrustedURL(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	assertOK := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.Query().Get("url")
@@ -36,7 +36,7 @@ func TestTrustedURL(t *testing.T) {
 		"invalid URL":         {Value: "://", ExpectedStatus: http.StatusBadRequest},
 	} {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			rec := httptest.NewRecorder()
 			middleware := middleware.TrustedURL(assertOK)

--- a/pkg/api/version_test.go
+++ b/pkg/api/version_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestGetRenderVersion(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("version is semver compatible", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		rec := httptest.NewRecorder()
 		handler := api.HandleGetRenderVersion(service.NewVersionService())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -207,7 +207,7 @@ func TestRenderRequestConfig(t *testing.T) {
 
 // TestBrowserOverrideFlag tests the eager config building with --browser.override flag
 func TestBrowserOverrideFlag(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	// Create a test command with browser flags
 	testCmd := &cli.Command{
@@ -438,7 +438,7 @@ func TestBrowserOverrideFlag(t *testing.T) {
 
 // TestReconstructFlags tests the flag reconstruction utility
 func TestReconstructFlags(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("reconstructs set flags", func(t *testing.T) {
 		var reconstructed []string
@@ -495,7 +495,7 @@ func TestReconstructFlags(t *testing.T) {
 
 // TestEagerConfigValidation tests that config validation happens at startup
 func TestEagerConfigValidation(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	// Create a command that exercises the eager config building
 	cmd := &cli.Command{

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewRegistryWorks(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	require.NotPanics(t, func() {
 		// We use MustRegister, which can panic. We just want to make sure it doesn't in this case.

--- a/pkg/service/version_test.go
+++ b/pkg/service/version_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPrettyVersion(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	if !isGitVcs(t) {
 		t.Skip("skipping test, not built with -buildvcs")
 	}
@@ -21,7 +21,7 @@ func TestPrettyVersion(t *testing.T) {
 }
 
 func TestRenderVersion(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	svc := service.NewVersionService()
 	version := svc.GetRenderVersion()

--- a/tests/acceptance/basic_render_test.go
+++ b/tests/acceptance/basic_render_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestBasicRenders(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("render PDF of service's root route", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		svc := StartImageRenderer(t)
 
@@ -37,7 +37,7 @@ func TestBasicRenders(t *testing.T) {
 	})
 
 	t.Run("render PNG of service's root route", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		svc := StartImageRenderer(t)
 

--- a/tests/acceptance/chromium_test.go
+++ b/tests/acceptance/chromium_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestChromiumInstalled(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	exitCode, logs := RunImageRendererWithCommand(t, []string{"chromium", "--version"}, nil)
 	require.Zero(t, exitCode, "chromium did not exist in the container (--version failed)")

--- a/tests/acceptance/expected_failures_test.go
+++ b/tests/acceptance/expected_failures_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAuthTokenFailures(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	svc := StartImageRenderer(t)
 
@@ -21,7 +21,7 @@ func TestAuthTokenFailures(t *testing.T) {
 		"wrong token":      ptr("wrong"),
 	} {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render?url=http://localhost:8081/", nil)
 			require.NoError(t, err, "could not construct HTTP request to /render")
@@ -38,7 +38,7 @@ func TestAuthTokenFailures(t *testing.T) {
 
 func TestRejectedURLs(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	svc := StartImageRenderer(t)
 
@@ -49,7 +49,7 @@ func TestRejectedURLs(t *testing.T) {
 		"socket scheme": "socket://localhost:8081/",
 	} {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render?url="+url, nil)
 			require.NoError(t, err, "could not construct HTTP request to /render")
@@ -65,7 +65,7 @@ func TestRejectedURLs(t *testing.T) {
 
 func TestInvalidQueryParameters(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	svc := StartImageRenderer(t)
 
@@ -77,7 +77,7 @@ func TestInvalidQueryParameters(t *testing.T) {
 		// "unknown encoding": {"url": "http://localhost:8081/", "encoding": "invalid"}, // node.js doesn't do this
 	} {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			reqURL, err := url.Parse(svc.HTTPEndpoint + "/render")
 			require.NoError(t, err, "could not parse /render URL")
@@ -100,10 +100,10 @@ func TestInvalidQueryParameters(t *testing.T) {
 }
 
 func TestBrowserTimeout(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("if the browser readiness timeout is exceeded, it returns a 408 status code", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		// extremely low that no request could ever be server in the alloted time
 		svc := StartImageRenderer(t, WithEnv("BROWSER_READINESS_TIMEOUT", "1ns"))

--- a/tests/acceptance/liveness_test.go
+++ b/tests/acceptance/liveness_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestServiceStartsHealthily(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	svc := StartImageRenderer(t)
 

--- a/tests/acceptance/metrics_test.go
+++ b/tests/acceptance/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMetricsEndpoint(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	svc := StartImageRenderer(t,
 		WithEnv("ENABLE_METRICS", "true")) // only required for node.js

--- a/tests/acceptance/overrides_test.go
+++ b/tests/acceptance/overrides_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRequestConfigOverrides(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	rendererAuthToken := strings.Repeat("-", 512/8)
 	joseSigner, err := jose.NewSigner(jose.SigningKey{
@@ -27,7 +27,7 @@ func TestRequestConfigOverrides(t *testing.T) {
 	require.NoError(t, err, "could not serialize JWT")
 
 	t.Run("min width and height overrides by URL pattern", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")
@@ -56,7 +56,7 @@ func TestRequestConfigOverrides(t *testing.T) {
 			WithEnv("GF_RENDERING_RENDERER_TOKEN", rendererAuthToken))
 
 		t.Run("non-matching URL uses default min dimensions (1000x1000)", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request")
@@ -86,7 +86,7 @@ func TestRequestConfigOverrides(t *testing.T) {
 		})
 
 		t.Run("matching URL uses override min dimensions (500x500)", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request")

--- a/tests/acceptance/regression_676_test.go
+++ b/tests/acceptance/regression_676_test.go
@@ -9,7 +9,7 @@ import (
 // Regression test for: https://github.com/grafana/grafana-image-renderer/issues/676
 func TestRegression676(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	for tool, cmd := range map[string]string{
 		"openssl tools":          "openssl version",
@@ -17,7 +17,7 @@ func TestRegression676(t *testing.T) {
 		"certutil":               "command -v certutil",
 	} {
 		t.Run("image contains: "+tool, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			exitCode, logs := RunImageRendererWithCommand(t, []string{"sh", "-c"}, []string{cmd})
 			require.Zero(t, exitCode, "%q did not exist in the container (command failed)", tool)

--- a/tests/acceptance/regression_677_test.go
+++ b/tests/acceptance/regression_677_test.go
@@ -10,10 +10,10 @@ import (
 // Regression test for: https://github.com/grafana/grafana-image-renderer/issues/677
 func TestRegression677(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("entrypoint is wrapped in tini", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		client, err := testcontainers.NewDockerClientWithOpts(t.Context())
 		require.NoError(t, err, "could not create Docker client")

--- a/tests/acceptance/regression_680_test.go
+++ b/tests/acceptance/regression_680_test.go
@@ -9,16 +9,16 @@ import (
 // Regression test for: https://github.com/grafana/grafana-image-renderer/issues/680
 func TestRegression680(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("lang is en_US.UTF-8", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		// The LANG environment variable should be set to en_US.UTF-8, which makes Chromium able to deal with non-ASCII characters properly.
 
 		for _, cmd := range []string{"echo $LANG", "echo $LC_ALL"} {
 			t.Run(cmd, func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				exitCode, logs := RunImageRendererWithCommand(t, []string{"sh", "-c"}, []string{cmd})
 				require.Zero(t, exitCode, "command %q did not run successfully", cmd)

--- a/tests/acceptance/regression_686_test.go
+++ b/tests/acceptance/regression_686_test.go
@@ -11,10 +11,10 @@ import (
 // Regression test for: https://github.com/grafana/grafana-image-renderer/issues/686
 func TestRegression686(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("kubernetes behaviour: user is set to numeric UID", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		client, err := testcontainers.NewDockerClientWithOpts(t.Context())
 		require.NoError(t, err, "could not create Docker client")
@@ -27,7 +27,7 @@ func TestRegression686(t *testing.T) {
 		require.Greater(t, uid, 0, "image user UID should be greater than 0")
 
 		t.Run("UID is same as nonroot user", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			exitCode, logs := RunImageRendererWithCommand(t, []string{"id", "-u"}, nil,
 				WithUser("nonroot"))

--- a/tests/acceptance/regression_694_test.go
+++ b/tests/acceptance/regression_694_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestRegression694(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	t.Run("openshift: docker image is alive when using random UID", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 		// https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/creating-images#use-uid_create-images
 		//   > Because the container user is always a member of the root group, the container user can read and write these files.
 		// https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids

--- a/tests/acceptance/regression_817_test.go
+++ b/tests/acceptance/regression_817_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRegression817(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	for font, fileName := range map[string]string{
 		"Inter":      "Inter-Regular.otf",
@@ -18,7 +18,7 @@ func TestRegression817(t *testing.T) {
 		"sans-serif": "DejaVuSans.ttf",
 	} {
 		t.Run(fmt.Sprintf("font %q is provided by %q", font, fileName), func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			// use fc-match ${font}
 			exitCode, logs := RunImageRendererWithCommand(t, []string{"fc-match", font}, []string{})

--- a/tests/acceptance/rendering_grafana_test.go
+++ b/tests/acceptance/rendering_grafana_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRenderingGrafana(t *testing.T) {
 	LongTest(t)
-	// t.Parallel()
+	t.Parallel()
 
 	rendererAuthToken := strings.Repeat("-", 512/8)
 	joseSigner, err := jose.NewSigner(jose.SigningKey{
@@ -36,7 +36,7 @@ func TestRenderingGrafana(t *testing.T) {
 	const defaultPixelDiff = 15_000
 
 	t.Run("render prometheus dashboard as PNG", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")
@@ -51,7 +51,7 @@ func TestRenderingGrafana(t *testing.T) {
 			WithEnv("GF_RENDERING_RENDERER_TOKEN", rendererAuthToken))
 
 		t.Run("with set width and height", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -80,7 +80,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with very low height and width", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -109,7 +109,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with d-solo link", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -138,7 +138,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with d-solo link and very low width and height", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -167,7 +167,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with d-solo link and scaling", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			const scaleFactor = 5
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
@@ -199,7 +199,7 @@ func TestRenderingGrafana(t *testing.T) {
 	})
 
 	t.Run("render prometheus dashboard as CSV", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 		OnlyEnterprise(t)
 
 		net, err := network.New(t.Context())
@@ -215,7 +215,7 @@ func TestRenderingGrafana(t *testing.T) {
 			WithEnv("GF_RENDERING_RENDERER_TOKEN", rendererAuthToken))
 
 		t.Run("with defaults", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render/csv", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -247,7 +247,7 @@ func TestRenderingGrafana(t *testing.T) {
 	})
 
 	t.Run("render prometheus dashboard as PDF", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")
@@ -262,7 +262,7 @@ func TestRenderingGrafana(t *testing.T) {
 			WithEnv("GF_RENDERING_RENDERER_TOKEN", rendererAuthToken))
 
 		t.Run("with defaults", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -290,7 +290,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with deviceScaleFactor", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -319,7 +319,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with US English language", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -350,7 +350,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("with German language", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -382,7 +382,7 @@ func TestRenderingGrafana(t *testing.T) {
 
 		for _, paper := range []string{"letter", "legal", "tabloid", "ledger", "a0", "a1", "a2", "a3", "a4", "a5", "a6"} {
 			t.Run("print with paper="+paper, func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 				require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -412,7 +412,7 @@ func TestRenderingGrafana(t *testing.T) {
 
 		for _, printBackground := range []bool{true, false} {
 			t.Run(fmt.Sprintf("print with background=%v", printBackground), func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 				require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -442,7 +442,7 @@ func TestRenderingGrafana(t *testing.T) {
 	})
 
 	t.Run("render very long prometheus dashboard", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")
@@ -457,7 +457,7 @@ func TestRenderingGrafana(t *testing.T) {
 			WithEnv("GF_RENDERING_RENDERER_TOKEN", rendererAuthToken))
 
 		t.Run("render PDF of many pages", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 			require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -486,7 +486,7 @@ func TestRenderingGrafana(t *testing.T) {
 
 		for _, isLandscape := range []bool{true, false} {
 			t.Run("pdf.landscape="+fmt.Sprintf("%v", isLandscape), func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 				require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -524,7 +524,7 @@ func TestRenderingGrafana(t *testing.T) {
 			"1 and 3":         "1, 3",
 		} {
 			t.Run("print PDF with pageRanges="+name, func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 				require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -553,11 +553,11 @@ func TestRenderingGrafana(t *testing.T) {
 		}
 
 		t.Run("render many pages as PNG with full height", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			for _, isLandscape := range []bool{true, false} {
 				t.Run("landscape="+fmt.Sprintf("%v", isLandscape), func(t *testing.T) {
-					// t.Parallel()
+					t.Parallel()
 
 					req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, svc.HTTPEndpoint+"/render", nil)
 					require.NoError(t, err, "could not construct HTTP request to Grafana")
@@ -589,7 +589,7 @@ func TestRenderingGrafana(t *testing.T) {
 	})
 
 	t.Run("render panel dashboards as PNG", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")
@@ -625,10 +625,10 @@ func TestRenderingGrafana(t *testing.T) {
 		}
 
 		t.Run("geomap", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			t.Run("with default settings", func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				body := requestDashboard(t, "default-geomap")
 				bodyImg := ReadRGBA(t, body)
@@ -640,7 +640,7 @@ func TestRenderingGrafana(t *testing.T) {
 			})
 
 			t.Run("with USA states flight info", func(t *testing.T) {
-				// t.Parallel()
+				t.Parallel()
 
 				body := requestDashboard(t, "geomap-with-usa-flights")
 				bodyImg := ReadRGBA(t, body)
@@ -653,7 +653,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("stat panels", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			body := requestDashboard(t, "stat-panels")
 			bodyImg := ReadRGBA(t, body)
@@ -665,7 +665,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("bar chart panels", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			body := requestDashboard(t, "bar-charts")
 			bodyImg := ReadRGBA(t, body)
@@ -677,7 +677,7 @@ func TestRenderingGrafana(t *testing.T) {
 		})
 
 		t.Run("gauge panels", func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 
 			body := requestDashboard(t, "gauge-panels")
 			bodyImg := ReadRGBA(t, body)
@@ -690,7 +690,7 @@ func TestRenderingGrafana(t *testing.T) {
 	})
 
 	t.Run("render dashboard as png with scaling", func(t *testing.T) {
-		// t.Parallel()
+		t.Parallel()
 
 		net, err := network.New(t.Context())
 		require.NoError(t, err, "could not create Docker network")


### PR DESCRIPTION
The acceptance tests were getting quite flaky as we added more, while running in the standard CI runner, so I had disabled the parallel tests, which improved the flakiness.

We can instead use a more beefier runner and re-enable the parallelism :)