### PR TITLE
Browser: Handle environment without XDG related environment variables

### DIFF
--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -439,7 +439,7 @@ func (s *BrowserService) createAllocatorOptions(ctx context.Context, cfg config.
 	if _, exists := os.LookupEnv("XDG_CONFIG_HOME"); !exists {
 		opts = append(opts, chromedp.Env("XDG_CONFIG_HOME="+cwd))
 	}
-	if _, exists = os.LookupEnv("XDG_CACHE_HOME"); !exists {
+	if _, exists := os.LookupEnv("XDG_CACHE_HOME"); !exists {
 		opts = append(opts, chromedp.Env("XDG_CACHE_HOME="+cwd))
 	}
 


### PR DESCRIPTION
If the XDG_CACHE_HOME and/or XDG_CONFIG_HOME env vars are not set, we use the temp folder as `XDG_CACHE_HOME` and/or `XDG_CONFIG_HOME`.

Fixes #892