### PR TITLE
Add TLS configuration to server listener

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -49,6 +49,8 @@ func ListenAndServe(parentCtx context.Context, cfg config.ServerConfig, handler 
 			Certificates: []tls.Certificate{keyPair},
 			MinVersion:   minVersion,
 		}
+
+		listener = tls.NewListener(listener, tlsConfig)
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
Currently server always uses HTTP even if SSL certs are provided, becaue default HTTP listner gets created at the beginning, and no TLS on top of it

Test:
```
./grafana-image-renderer server  --server.cert identity.cert --server.key identity.key
```

before:
```
curl -k https://localhost:8081/healthz
curl: (35) OpenSSL/1.1.1k: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
```

after
```
curl -k "https://localhost:8081/healthz"
OK
```