### PR TITLE
API: Add config flag to disable request logging for certain paths

### DIFF
--- a/docs/sources/flags.md
+++ b/docs/sources/flags.md
@@ -50,6 +50,8 @@ This is a verbatim copy of the output of the `grafana-image-renderer server --he
 ```
 --api.default-encoding=<string> [default: "pdf"] [${API_DEFAULT_ENCODING}]
     The default encoding for render requests when not specified. (values: pdf, png) [config: api.default-encoding]
+--api.silence-request-log-path=<string> [${API_SILENCE_REQUEST_LOG_PATH}]
+    Allows silencing the HTTP request logs for a certain path. It requires a direct match. Multiple values can be passed separated by comma or multiple flags. Examples: '/healthz', '/render/version'. [config: api.silence-request-log-path]
 --browser.flag=<string> / --browser.flags=<string> [${BROWSER_FLAGS}, ${BROWSER_FLAG}]
     Flags to pass to the browser. These are syntaxed `--${flag}` or `--${flag}=${value}`. Note the required `--` prefix for each flag. [config: browser.flag]
 --browser.gpu [default: false] [${BROWSER_GPU}]

--- a/pkg/api/middleware/logger.go
+++ b/pkg/api/middleware/logger.go
@@ -3,15 +3,22 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
+
+	"github.com/grafana/grafana-image-renderer/pkg/config"
 )
 
-func RequestLogger(h http.Handler) http.Handler {
+func RequestLogger(apiConfig config.APIConfig, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		lw := &loggingResponseWriter{w: w}
 		defer func() {
+			if len(apiConfig.APISilenceRequestLogPath) > 0 && slices.Contains(apiConfig.APISilenceRequestLogPath, r.URL.Path) {
+				return
+			}
+
 			slog.InfoContext(r.Context(), "request complete",
 				"method", r.Method,
 				"mux_pattern", r.Pattern,

--- a/pkg/api/mux.go
+++ b/pkg/api/mux.go
@@ -53,7 +53,7 @@ func NewHandler(
 	mux.Handle("GET /render/version", HandleGetRenderVersion(versions))
 
 	handler := middleware.RequestMetrics(mux)
-	handler = middleware.RequestLogger(handler)
+	handler = middleware.RequestLogger(apiConfig, handler)
 	handler = middleware.Recovery(handler)
 	handler = middleware.Tracing(handler)
 	return handler, nil


### PR DESCRIPTION
It allows users to selectively disable the request logging middleware for certain paths. This is likely to be used for `/healthz` and potentially for `/render/version` endpoints to provide cleaner logs.

Closes https://github.com/grafana/grafana-image-renderer/issues/929