### PR TITLE
Go: Update to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #        -> Why static linking? We want to ensure we can switch base-image with little to no effort.
 #   2. It builds a running environment. This is the environment that exists for the Go binary, and should have all necessary pieces to run the application.
 
-FROM golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS app
+FROM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS app
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-image-renderer
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Addresses:
- CVE-2026-32282
- CVE-2026-32289
- CVE-2026-27144
- CVE-2026-27143
- CVE-2026-32288
- CVE-2026-32283
- CVE-2026-27140
- CVE-2026-32280
- CVE-2026-32281