### PR TITLE
Docker: Update Chromium to 147.0.7727.55 and Debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build \
   -ldflags '-s -w -extldflags "-static"' \
   .
 
-FROM debian:13@sha256:55a15a112b42be10bfc8092fcc40b6748dc236f7ef46a358d9392b339e9d60e8 AS output_image
+FROM debian:13@sha256:3352c2e13876c8a5c5873ef20870e1939e73cb9a3c1aeba5e3e72172a85ce9ed AS output_image
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-04-06' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-04-13' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=146.0.7680.177
+ARG CHROMIUM_VERSION=147.0.7727.55
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Addresses:
- CVE-2026-4775
- CVE-2026-5858
- CVE-2026-5859
- CVE-2026-5860
- CVE-2026-5861
- CVE-2026-5862
- CVE-2026-5863
- CVE-2026-5864
- CVE-2026-5865
- CVE-2026-5866
- CVE-2026-5867
- CVE-2026-5868
- CVE-2026-5869
- CVE-2026-5870
- CVE-2026-5871
- CVE-2026-5872
- CVE-2026-5873
- CVE-2026-5874
- CVE-2026-5875
- CVE-2026-5876
- CVE-2026-5877
- CVE-2026-5878
- CVE-2026-5879
- CVE-2026-5880
- CVE-2026-5881
- CVE-2026-5882
- CVE-2026-5883
- CVE-2026-5884
- CVE-2026-5885
- CVE-2026-5886
- CVE-2026-5887
- CVE-2026-5888
- CVE-2026-5889
- CVE-2026-5890
- CVE-2026-5891
- CVE-2026-5892
- CVE-2026-5893
- CVE-2026-5894
- CVE-2026-5895
- CVE-2026-5896
- CVE-2026-5897
- CVE-2026-5898
- CVE-2026-5899
- CVE-2026-5900
- CVE-2026-5901
- CVE-2026-5902
- CVE-2026-5903
- CVE-2026-5904
- CVE-2026-5905
- CVE-2026-5906
- CVE-2026-5907
- CVE-2026-5908
- CVE-2026-5909
- CVE-2026-5910
- CVE-2026-5911
- CVE-2026-5912
- CVE-2026-5913
- CVE-2026-5914
- CVE-2026-5915
- CVE-2026-5918
- CVE-2026-5919
