### PR TITLE
Docker: Update Chromium to 147.0.7727.101

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-04-13' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-04-20' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=147.0.7727.55
+ARG CHROMIUM_VERSION=147.0.7727.101
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Addresses:
- CVE-2026-6296
- CVE-2026-6297
- CVE-2026-6298
- CVE-2026-6299
- CVE-2026-6358
- CVE-2026-6359
- CVE-2026-6300
- CVE-2026-6301
- CVE-2026-6302
- CVE-2026-6303
- CVE-2026-6304
- CVE-2026-6305
- CVE-2026-6306
- CVE-2026-6307
- CVE-2026-6308
- CVE-2026-6309
- CVE-2026-6360
- CVE-2026-6310
- CVE-2026-6311
- CVE-2026-6312
- CVE-2026-6313
- CVE-2026-6314
- CVE-2026-6315
- CVE-2026-6316
- CVE-2026-6361
- CVE-2026-6362
- CVE-2026-6317
- CVE-2026-6363
- CVE-2026-6318
- CVE-2026-6319
- CVE-2026-6364