### PR TITLE
Docker: Update Chromium to 147.0.7727.137

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build \
   -ldflags '-s -w -extldflags "-static"' \
   .
 
-FROM debian:13@sha256:3352c2e13876c8a5c5873ef20870e1939e73cb9a3c1aeba5e3e72172a85ce9ed AS output_image
+FROM debian:13@sha256:35b8ff74ead4880f22090b617372daff0ccae742eb5674455d542bef71ef1999 AS output_image
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-04-20' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-05-04' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=147.0.7727.101
+ARG CHROMIUM_VERSION=147.0.7727.137
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Addresses:
- CVE-2026-7363
- CVE-2026-7361
- CVE-2026-7344
- CVE-2026-7343
- CVE-2026-7333
- CVE-2026-7360
- CVE-2026-7359
- CVE-2026-7358
- CVE-2026-7334
- CVE-2026-7357
- CVE-2026-7356
- CVE-2026-7354
- CVE-2026-7353
- CVE-2026-7352
- CVE-2026-7351
- CVE-2026-7350
- CVE-2026-7349
- CVE-2026-7348
- CVE-2026-7335
- CVE-2026-7336
- CVE-2026-7337
- CVE-2026-7347
- CVE-2026-7346
- CVE-2026-7345
- CVE-2026-7338
- CVE-2026-7342
- CVE-2026-7341
- CVE-2026-7339
- CVE-2026-7340
- CVE-2026-7355
- CVE-2026-6919
- CVE-2026-6920
- CVE-2026-6921