### PR TITLE
Docker: Update Chromium to 148.0.7778.167

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-05-04' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-05-18' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=147.0.7727.137
+ARG CHROMIUM_VERSION=148.0.7778.167
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Addresses/clears:
- CVE-2026-8509
- CVE-2026-8510
- CVE-2026-8511
- CVE-2026-8512
- CVE-2026-8513
- CVE-2026-8514
- CVE-2026-8515
- CVE-2026-8516
- CVE-2026-8517
- CVE-2026-8518
- CVE-2026-8519
- CVE-2026-8520
- CVE-2026-8521
- CVE-2026-8522
- CVE-2026-8523
- CVE-2026-8558
- CVE-2026-8524
- CVE-2026-8525
- CVE-2026-8526
- CVE-2026-8527
- CVE-2026-8528
- CVE-2026-8529
- CVE-2026-8530
- CVE-2026-8531
- CVE-2026-8532
- CVE-2026-8533
- CVE-2026-8534
- CVE-2026-8535
- CVE-2026-8536
- CVE-2026-8537
- CVE-2026-8538
- CVE-2026-8539
- CVE-2026-8540
- CVE-2026-8541
- CVE-2026-8542
- CVE-2026-8543
- CVE-2026-8544
- CVE-2026-8545
- CVE-2026-8546
- CVE-2026-8547
- CVE-2026-8548
- CVE-2026-8549
- CVE-2026-8550
- CVE-2026-8551
- CVE-2026-8552
- CVE-2026-8553
- CVE-2026-8554
- CVE-2026-8555
- CVE-2026-8556
- CVE-2026-8557
- CVE-2026-8559
- CVE-2026-8560
- CVE-2026-8561
- CVE-2026-8562
- CVE-2026-8563
- CVE-2026-8564
- CVE-2026-8565
- CVE-2026-8566
- CVE-2026-8567
- CVE-2026-8568
- CVE-2026-8569
- CVE-2026-8570
- CVE-2026-8571
- CVE-2026-8572
- CVE-2026-8573
- CVE-2026-8574
- CVE-2026-8575
- CVE-2026-8576
- CVE-2026-8577
- CVE-2026-8578
- CVE-2026-8579
- CVE-2026-8580
- CVE-2026-8581
- CVE-2026-8582
- CVE-2026-8583
- CVE-2026-8584
- CVE-2026-8585
- CVE-2026-8586
- CVE-2026-8587
- CVE-2026-7896
- CVE-2026-7897
- CVE-2026-7898
- CVE-2026-7899
- CVE-2026-7900
- CVE-2026-7901
- CVE-2026-7902
- CVE-2026-7903
- CVE-2026-7904
- CVE-2026-7905
- CVE-2026-7906
- CVE-2026-7907
- CVE-2026-7908
- CVE-2026-7909
- CVE-2026-7910
- CVE-2026-7911
- CVE-2026-7912
- CVE-2026-7913
- CVE-2026-7914
- CVE-2026-7915
- CVE-2026-7916
- CVE-2026-7917
- CVE-2026-7918
- CVE-2026-7919
- CVE-2026-7920
- CVE-2026-7921
- CVE-2026-7922
- CVE-2026-7923
- CVE-2026-7924
- CVE-2026-7925
- CVE-2026-7926
- CVE-2026-7927
- CVE-2026-7928
- CVE-2026-7929
- CVE-2026-7930
- CVE-2026-7931
- CVE-2026-7932
- CVE-2026-7933
- CVE-2026-7934
- CVE-2026-7935
- CVE-2026-7936
- CVE-2026-7937
- CVE-2026-7938
- CVE-2026-7939
- CVE-2026-7940
- CVE-2026-7941
- CVE-2026-7942
- CVE-2026-7943
- CVE-2026-7944
- CVE-2026-7945
- CVE-2026-7946
- CVE-2026-7947
- CVE-2026-7948
- CVE-2026-7949
- CVE-2026-7950
- CVE-2026-7951
- CVE-2026-7952
- CVE-2026-7953
- CVE-2026-7954
- CVE-2026-7955
- CVE-2026-7956
- CVE-2026-7957
- CVE-2026-7958
- CVE-2026-7959
- CVE-2026-7960
- CVE-2026-7961
- CVE-2026-7962
- CVE-2026-7963
- CVE-2026-7964
- CVE-2026-7965
- CVE-2026-7966
- CVE-2026-7967
- CVE-2026-7968
- CVE-2026-7969
- CVE-2026-7970
- CVE-2026-7971
- CVE-2026-7972
- CVE-2026-7973
- CVE-2026-7974
- CVE-2026-7975
- CVE-2026-7976
- CVE-2026-7977
- CVE-2026-7978
- CVE-2026-7979
- CVE-2026-7980
- CVE-2026-7981
- CVE-2026-7982
- CVE-2026-7983
- CVE-2026-7984
- CVE-2026-7985
- CVE-2026-7986
- CVE-2026-7987
- CVE-2026-7988
- CVE-2026-7989
- CVE-2026-7990
- CVE-2026-7991
- CVE-2026-7992
- CVE-2026-7993
- CVE-2026-7994
- CVE-2026-7995
- CVE-2026-7996
- CVE-2026-7997
- CVE-2026-7998
- CVE-2026-7999
- CVE-2026-8000
- CVE-2026-8001
- CVE-2026-8002
- CVE-2026-8003
- CVE-2026-8004
- CVE-2026-8005
- CVE-2026-8006
- CVE-2026-8007
- CVE-2026-8008
- CVE-2026-8009
- CVE-2026-8010
- CVE-2026-8011
- CVE-2026-8012
- CVE-2026-8013
- CVE-2026-8014
- CVE-2026-8015
- CVE-2026-8016
- CVE-2026-8017
- CVE-2026-8018
- CVE-2026-8019
- CVE-2026-8020
- CVE-2026-8021
- CVE-2026-8022