### PR TITLE
build: Migrate Docker image publishing to GAR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,17 +62,19 @@ jobs:
       registry: ${{ steps.image_tag.outputs.registry }}
       ref_name: ${{ steps.image_tag.outputs.ref_name }}
     steps:
-      - name: Use GAR dev
+      - name: Use ghcr.io
         if: github.event_name != 'push' || github.ref_type != 'tag'
+        env:
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "REGISTRY=us-docker.pkg.dev" >> "$GITHUB_ENV"
-          echo "REPOSITORY=grafanalabs-dev/docker-grafana-image-renderer-dev/grafana-image-renderer" >> "$GITHUB_ENV"
-      - name: Use GAR prod
+          echo "REGISTRY=ghcr.io" >> "$GITHUB_ENV"
+          echo "REPOSITORY=$REPOSITORY" >> "$GITHUB_ENV"
+      - name: Use GAR
         if: github.event_name == 'push' && github.ref_type == 'tag'
         run: |
           echo "REGISTRY=us-docker.pkg.dev" >> "$GITHUB_ENV"
-          echo "REPOSITORY=grafanalabs-global/docker-grafana-image-renderer-prod/grafana-image-renderer" >> "$GITHUB_ENV"
+          echo "REPOSITORY=grafanalabs-global/dockerhub-grafana-image-renderer-prod-mirror/grafana-image-renderer" >> "$GITHUB_ENV"
 
       - name: Use Git tag for image tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -113,12 +115,22 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read # required to read the repository contents
+      packages: write # required to push the built image to the package registry
       attestations: write # required to create attestations for the built image
-      id-token: write # required to authenticate to GAR and create attestations
+      id-token: write # required to create attestations for the built image, and to read secrets
       pull-requests: write # required to comment on the pull request
     steps:
+      - name: Log into GHCR
+        if: needs.tag.outputs.registry == 'ghcr.io'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
       - name: Log into GAR
-        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223
+        if: needs.tag.outputs.registry == 'us-docker.pkg.dev'
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - uses: actions/checkout@v6
         with:
@@ -155,11 +167,21 @@ jobs:
     name: Create manifests
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # required to authenticate to GAR
+      packages: write # required to create the manifest list in the package registry
+      id-token: write # required to create the manifest list in the package registry
       pull-requests: write # required to comment on the pull request
     steps:
+      - name: Log into GHCR
+        if: needs.tag.outputs.registry == 'ghcr.io'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
       - name: Log into GAR
-        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223
+        if: needs.tag.outputs.registry == 'us-docker.pkg.dev'
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: Create and push manifests
         env:
@@ -194,6 +216,7 @@ jobs:
 
             > [!WARNING]
             > This is a development image and should not be used in production.
+            > It will be automatically removed after 1 week.
 
   release:
     name: Create GitHub Release
@@ -202,6 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # to create the release
+      packages: read # to read the package information
     steps:
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,7 +206,7 @@ jobs:
         continue-on-error: true # just check the actions log if ratelimits or whatever
         with:
           message: |
-            :whale: Docker image built and pushed to Google Artifact Registry.
+            :whale: Docker image built and pushed to GitHub Container Registry.
 
             You can pull it using:
 
@@ -216,7 +216,7 @@ jobs:
 
             > [!WARNING]
             > This is a development image and should not be used in production.
-            > It will be automatically removed after 1 week.
+            > It will be automatically removed after 2 weeks.
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,19 +62,17 @@ jobs:
       registry: ${{ steps.image_tag.outputs.registry }}
       ref_name: ${{ steps.image_tag.outputs.ref_name }}
     steps:
-      - name: Use ghcr.io
+      - name: Use GAR dev
         if: github.event_name != 'push' || github.ref_type != 'tag'
-        env:
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "REGISTRY=ghcr.io" >> "$GITHUB_ENV"
-          echo "REPOSITORY=$REPOSITORY" >> "$GITHUB_ENV"
-      - name: Use docker.io
+          echo "REGISTRY=us-docker.pkg.dev" >> "$GITHUB_ENV"
+          echo "REPOSITORY=grafanalabs-dev/docker-grafana-image-renderer-dev/grafana-image-renderer" >> "$GITHUB_ENV"
+      - name: Use GAR prod
         if: github.event_name == 'push' && github.ref_type == 'tag'
         run: |
-          echo "REGISTRY=docker.io" >> "$GITHUB_ENV"
-          echo "REPOSITORY=grafana/grafana-image-renderer" >> "$GITHUB_ENV"
+          echo "REGISTRY=us-docker.pkg.dev" >> "$GITHUB_ENV"
+          echo "REPOSITORY=grafanalabs-global/docker-grafana-image-renderer-prod/grafana-image-renderer" >> "$GITHUB_ENV"
 
       - name: Use Git tag for image tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -115,20 +113,12 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read # required to read the repository contents
-      packages: write # required to push the built image to the package registry
       attestations: write # required to create attestations for the built image
-      id-token: write # required to create attestations for the built image, and to read secrets
+      id-token: write # required to authenticate to GAR and create attestations
       pull-requests: write # required to comment on the pull request
     steps:
-      - name: Log into GHCR
-        if: needs.tag.outputs.registry == 'ghcr.io'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Log into DockerHub
-        if: needs.tag.outputs.registry == 'docker.io'
-        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223
 
       - uses: actions/checkout@v6
         with:
@@ -165,19 +155,11 @@ jobs:
     name: Create manifests
     runs-on: ubuntu-latest
     permissions:
-      packages: write # required to create the manifest list in the package registry
-      id-token: write # required to create the manifest list in the package registry
+      id-token: write # required to authenticate to GAR
       pull-requests: write # required to comment on the pull request
     steps:
-      - name: Log into GHCR
-        if: needs.tag.outputs.registry == 'ghcr.io'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Log into DockerHub
-        if: needs.tag.outputs.registry == 'docker.io'
-        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223
 
       - name: Create and push manifests
         env:
@@ -202,7 +184,7 @@ jobs:
         continue-on-error: true # just check the actions log if ratelimits or whatever
         with:
           message: |
-            :whale: Docker image built and pushed to GitHub Container Registry.
+            :whale: Docker image built and pushed to Google Artifact Registry.
 
             You can pull it using:
 
@@ -212,7 +194,6 @@ jobs:
 
             > [!WARNING]
             > This is a development image and should not be used in production.
-            > It will be automatically removed after 2 weeks.
 
   release:
     name: Create GitHub Release
@@ -221,7 +202,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # to create the release
-      packages: read # to read the package information
     steps:
       - uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## Summary

- Replaces Docker Hub (prod) and GHCR (dev) with Google Artifact Registry
- Dev builds (PRs, branch pushes) → `us-docker.pkg.dev/grafanalabs-dev/docker-grafana-image-renderer-dev/grafana-image-renderer`
- Prod builds (tags) → `us-docker.pkg.dev/grafanalabs-global/docker-grafana-image-renderer-prod/grafana-image-renderer`
- Uses `login-to-gar` shared workflow for OIDC-based auth — no DockerHub secrets needed

## Tracking

Depends on deployment_tools PR: https://github.com/grafana/deployment_tools/pull/590728