### PR TITLE
chore: enforce 7-day minimum release age Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "minimumReleaseAge": "7 days",
   "ignorePresets": [
     "github>grafana/grafana-renovate-config//presets/automerge",
     "github>grafana/grafana-renovate-config//presets/docker",


### PR DESCRIPTION
## Summary

Adds a `minimumReleaseAge` of 7 days to the Renovate configuration. This prevents Renovate from immediately proposing version bumps for packages published within the past week, reducing the risk of picking up yanked, broken, or quickly-patched releases before they stabilise.

## What changed

- **`renovate.json`**: Added top-level `"minimumReleaseAge": "7 days"` — applies to all enabled managers (currently `dockerfile` and `custom.regex`).

## Test Plan

- Verified the JSON is valid and the key is placed correctly at the top level of the config object.
- No runtime code changed; this is a Renovate config-only update that takes effect on the next Renovate run.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

The existing config only enables `dockerfile` and `custom.regex` managers, so this setting currently gates Debian package updates in the Dockerfile. If Go module management is added to Renovate in the future, the 7-day minimum will apply there automatically as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)