### PR TITLE
fix(ci): update container ghcr cleanup action

### DIFF
--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       packages: write # required to delete images from the package registry
     steps:
-      - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0
+      - uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         id: retention
         with:
           account: grafana


### PR DESCRIPTION
https://github.com/snok/container-retention-policy/compare/v3.0.0..v3.1.0

Fixes the workflow failing on new GH token formats.