### PR TITLE
Docker: Update Chromium to 149.0.7827.102

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-05-18' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-06-11' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=148.0.7778.167
+ARG CHROMIUM_VERSION=149.0.7827.102
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
From Debian's changelog:

```
chromium (149.0.7827.102-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE-2026-11628: Use after free in Ozone. Reported by Google.
    - CVE-2026-11629: Use after free in Ozone. Reported by Google.
    - CVE-2026-11630: Use after free in File Input. Reported by Google.
    - CVE-2026-11631: Use after free in Aura. Reported by Google.
    - CVE-2026-11632: Use after free in TabStrip. Reported by Google.
    - CVE-2026-11633: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-11634: Use after free in Gamepad. Reported by Google.
    - CVE-2026-11635: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-11636: Use after free in Autofill. Reported by Google.
    - CVE-2026-11637: Use after free in Views. Reported by Google.
    - CVE-2026-11638: Use after free in Printing. Reported by Google.
    - CVE-2026-11639: Use after free in Compositing. Reported by Google.
    - CVE-2026-11640: Integer overflow in libyuv. Reported by Google.
    - CVE-2026-11641: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-11642: Use after free in Web Apps. Reported by Google.
    - CVE-2026-11643: Use after free in Proxy. Reported by Google.
    - CVE-2026-11644: Use after free in Views. Reported by Google.
    - CVE-2026-11645: Out of bounds memory access in V8. Reported by 303f06e3
    - CVE-2026-11646: Use after free in ViewTransitions.
      Reported by Quac Tran.
    - CVE-2026-11647: Use after free in Printing. Reported by Google.
    - CVE-2026-11648: Use after free in FullScreen.
      Reported by Mihnea Nicolau.
    - CVE-2026-11649: Use after free in V8. Reported by Google.
    - CVE-2026-11650: Use after free in V8. Reported by Google.
    - CVE-2026-11651: Use after free in Network. Reported by Google.
    - CVE-2026-11652: Use after free in Extensions. Reported by Google.
    - CVE-2026-11653: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-11654: Use after free in CameraCapture. Reported by Google.
    - CVE-2026-11655: Integer overflow in Media. Reported by Google.
    - CVE-2026-11656: Use after free in ServiceWorker. Reported by Google.
    - CVE-2026-11657: Use after free in Payments. Reported by Google.
    - CVE-2026-11658: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-11659: Insufficient validation of untrusted input in UI.
      Reported by Google.
    - CVE-2026-11660: Insufficient validation of untrusted input in
      New Tab Page. Reported by Google.
    - CVE-2026-11661: Use after free in Views. Reported by Google.
    - CVE-2026-11662: Type Confusion in Bindings. Reported by Google.
    - CVE-2026-11663: Use after free in Skia. Reported by Google.
    - CVE-2026-11664: Use after free in Payments. Reported by Google.
    - CVE-2026-11665: Out of bounds read in Dawn. Reported by Google.
    - CVE-2026-11666: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-11667: Out of bounds read in WebRTC. Reported by Google.
    - CVE-2026-11668: Uninitialized Use in Codecs. Reported by Google.
    - CVE-2026-11669: Integer overflow in Media. Reported by Google.
    - CVE-2026-11670: Use after free in PDF. Reported by Google.
    - CVE-2026-11671: Use after free in Navigation. Reported by Google.
    - CVE-2026-11672: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-11673: Use after free in InterestGroups. Reported by Google.
    - CVE-2026-11674: Use after free in Guest View. Reported by Google.
    - CVE-2026-11675: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-11676: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-11677: Race in Network. Reported by Google.
    - CVE-2026-11678: Integer overflow in libyuv. Reported by Google.
    - CVE-2026-11679: Use after free in Codecs. Reported by Google.
    - CVE-2026-11680: Use after free in Media. Reported by Google.
    - CVE-2026-11681: Use after free in Ozone. Reported by Google.
    - CVE-2026-11682: Insufficient validation of untrusted input in Views.
      Reported by Google.
    - CVE-2026-11683: Use after free in WebCodecs. Reported by Google.
    - CVE-2026-11684: Insufficient policy enforcement in Network.
      Reported by Google.
    - CVE-2026-11685: Insufficient data validation in MediaCapture.
      Reported by Google.
    - CVE-2026-11686: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-11687: Use after free in Dawn. Reported by Google.
    - CVE-2026-11688: Object lifecycle issue in SVG. Reported by Google.
    - CVE-2026-11689: Insufficient validation of untrusted input in
      Passwords. Reported by Google.
    - CVE-2026-11690: Out of bounds read and write in Media.
      Reported by Google.
    - CVE-2026-11691: Insufficient validation of untrusted input in
      New Tab Page. Reported by Google.
    - CVE-2026-11692: Use after free in Read Anything. Reported by Google.
    - CVE-2026-11693: Inappropriate implementation in Plugins.
      Reported by Google.
    - CVE-2026-11694: Use after free in ServiceWorker. Reported by Google.
    - CVE-2026-11695: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-11696: Uninitialized Use in Video. Reported by Google.
    - CVE-2026-11697: Insufficient validation of untrusted input in UI.
      Reported by Google.
    - CVE-2026-11698: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-11699: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-11700: Use after free in Tracing. Reported by Google.
    - CVE-2026-11701: Insufficient validation of untrusted input in Guest
      View. Reported by Google.
  * d/patches:
    - fixes/arm-logging.patch: add patch to hopefully fix build failure
      on arm*.
    - loongarch64/0024-fix-libyuv-lsx.patch: refresh.

  [ Timothy Pearson ]
  * d/patches/ppc64le:
    - 0001-Add-pregenerated-config-for-libaom-on-ppc64.patch: refresh for
      upstream changes
    - core/baseline-isa-3-0.patch: refresh

 -- Andres Salomon <dilinger@debian.org>  Tue, 09 Jun 2026 04:00:45 -0400

chromium (149.0.7827.53-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream stable release.
    - CVE-2026-10881: Out of bounds read and write in ANGLE.
      Reported by Anonymous.
    - CVE-2026-10882: Use after free in Network.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-10883: Out of bounds write in ANGLE. Reported by Maher Azzouzi.
    - CVE-2026-10884: Use after free in Chromecast. Reported by Google.
    - CVE-2026-10885: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-10886: Use after free in FileSystem. Reported by Andrew Boni.
    - CVE-2026-10887: Use after free in Chromoting. Reported by Google.
    - CVE-2026-10888: Use after free in Cast Streaming. Reported by Google.
    - CVE-2026-10889: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-10890: Use after free in Cast. Reported by Google.
    - CVE-2026-10891: Use after free in GFX. Reported by Google.
    - CVE-2026-10892: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-10893: Use after free in Chromoting. Reported by Google.
    - CVE-2026-10894: Use after free in Printing. Reported by Google.
    - CVE-2026-10895: Use after free in Ozone. Reported by Google.
    - CVE-2026-10896: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-10897: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-10898: Stack buffer overflow in GPU. Reported by Google.
    - CVE-2026-10899: Use after free in Ozone. Reported by Google.
    - CVE-2026-10900: Use after free in Passwords. Reported by Google.
    - CVE-2026-10901: Use after free in Passwords. Reported by Google.
    - CVE-2026-10902: Use after free in Ozone. Reported by Google.
    - CVE-2026-10903: Use after free in WebRTC.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-10904: Inappropriate implementation in V8. Reported by 303f06e3
    - CVE-2026-10905: Use after free in Network.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-10906: Use after free in WebAuthentication.
      Reported by Weipeng Jiang (@Krace) of VRI.
    - CVE-2026-10907: Out of bounds write in ANGLE. Reported by sweetchip.
    - CVE-2026-10908: Use after free in FullScreen. Reported by Mihnea Nicolau
    - CVE-2026-10909: Use after free in Dawn. Reported by whiter@xuanyusec.
    - CVE-2026-10910: Type Confusion in V8.
      Reported by Mufeed VH from Winfunc Research (winfunc.com).
    - CVE-2026-10911: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-10912: Insufficient validation of untrusted input
      in Extensions. Reported by Google.
    - CVE-2026-10913: Use after free in ANGLE. Reported by Google.
    - CVE-2026-10914: Use after free in ANGLE. Reported by Google.
    - CVE-2026-10915: Use after free in Core. Reported by Google.
    - CVE-2026-10916: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-10917: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-10918: Use after free in Viz. Reported by Google.
    - CVE-2026-10919: Use after free in ANGLE. Reported by Google.
    - CVE-2026-10920: Insufficient validation of untrusted input in WebShare.
      Reported by Google.
    - CVE-2026-10921: Integer overflow in Dawn. Reported by Google.
    - CVE-2026-10922: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-10923: Use after free in WebAppInstalls. Reported by Google.
    - CVE-2026-10924: Integer overflow in Chromecast. Reported by Google.
    - CVE-2026-10925: Out of bounds write in Skia. Reported by Google.
    - CVE-2026-10926: Use after free in Cast. Reported by Google.
    - CVE-2026-10927: Out of bounds read in Dawn. Reported by Google.
    - CVE-2026-10928: Script injection in Headless. Reported by Google.
    - CVE-2026-10929: Heap buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-10930: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-10931: Use after free in FileSystem. Reported by asjidkalam.
    - CVE-2026-10932: Use after free in UI. Reported by Google.
    - CVE-2026-10933: Use after free in Audio. Reported by Google.
    - CVE-2026-10934: Use after free in Autofill. Reported by Google.
    - CVE-2026-10935: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-10936: Type Confusion in V8. Reported by Google.
    - CVE-2026-10937: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-10938: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-10939: Use after free in WebRTC. Reported by Google.
    - CVE-2026-10940: Race in Codecs. Reported by Google.
    - CVE-2026-10941: Out of bounds memory access in Skia. Reported by Google.
    - CVE-2026-10942: Insufficient validation of untrusted input in UI.
      Reported by Google.
    - CVE-2026-10943: Use after free in WebRTC. Reported by Rayyan Kadar.
    - CVE-2026-10944: Insufficient policy enforcement in Autofill.
      Reported by Google.
    - CVE-2026-10945: Use after free in PDF. Reported by Google.
    - CVE-2026-10946: Heap buffer overflow in Media. Reported by Google.
    - CVE-2026-10947: Use after free in WebRTC. Reported by Google.
    - CVE-2026-10948: Use after free in WebRTC. Reported by Google.
    - CVE-2026-10949: Heap buffer overflow in Video. Reported by Google.
    - CVE-2026-10950: Insufficient policy enforcement in Autofill.
      Reported by Google.
    - CVE-2026-10951: Use after free in Autofill. Reported by Google.
    - CVE-2026-10952: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-10953: Use after free in Core. Reported by Google.
    - CVE-2026-10954: Use after free in Actor. Reported by Google.
    - CVE-2026-10955: Type Confusion in ANGLE. Reported by Google.
    - CVE-2026-10956: Use after free in MimeHandlerView. Reported by Google.
    - CVE-2026-10957: Use after free in Glic. Reported by Google.
    - CVE-2026-10958: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-10959: Use after free in Input. Reported by Google.
    - CVE-2026-10960: Uninitialized Use in Codecs. Reported by Google.
    - CVE-2026-10961: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-10962: Type Confusion in Media. Reported by Google.
    - CVE-2026-10963: Integer overflow in V8. Reported by Google.
    - CVE-2026-10964: Integer overflow in V8. Reported by Google.
    - CVE-2026-10965: Integer overflow in DevTools. Reported by Google.
    - CVE-2026-10966: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-10967: Use after free in SurfaceCapture. Reported by Google.
    - CVE-2026-10968: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-10969: Insufficient validation of untrusted input in Extensions
      Reported by Google.
    - CVE-2026-10970: Insufficient validation of untrusted input
      in InterestGroups. Reported by Google.
    - CVE-2026-10971: Insufficient validation of untrusted input in Printing.
      Reported by Google.
    - CVE-2026-10972: Use after free in Ozone. Reported by Google.
    - CVE-2026-10973: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-10974: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-10975: Use after free in WebRTC. Reported by Google.
    - CVE-2026-10976: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-10977: Uninitialized Use in Skia. Reported by Google.
    - CVE-2026-10978: Use after free in Chromoting. Reported by Google.
    - CVE-2026-10979: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-10980: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-10981: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-10982: Use after free in WebXR. Reported by Google.
    - CVE-2026-10983: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-10984: Inappropriate implementation in Accessibility.
      Reported by Google.
    - CVE-2026-10985: Out of bounds read in Skia. Reported by Google.
    - CVE-2026-10986: Integer overflow in Media. Reported by Google.
    - CVE-2026-10987: Integer overflow in V8. Reported by Google.
    - CVE-2026-10988: Use after free in Views. Reported by Google.
    - CVE-2026-10989: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-10990: Use after free in Glic.
      Reported by Weipeng Jiang (@Krace) of VRI.
    - CVE-2026-10991: Use after free in V8.
      Reported by Alisa Esage (@alisaesage).
    - CVE-2026-10992: Insufficient data validation in Animation.
      Reported by heapracer (@heapracer).
    - CVE-2026-10993: Heap buffer overflow in Skia.
      Reported by M. Fauzan Wijaya (Gh05t666nero).
    - CVE-2026-10994: Uninitialized Use in ANGLE.
      Reported by Mufeed VH from Winfunc Research (winfunc.com).
    - CVE-2026-10995: Heap buffer overflow in TabStrip.
      Reported by Sven Dysthe (@svn-dys).
    - CVE-2026-10996: Inappropriate implementation in Workers.
      Reported by Jayateertha Guruprasad.
    - CVE-2026-10997: Insufficient policy enforcement in Extensions.
      Reported by djallalakira@gmail.com.
    - CVE-2026-10998: Out of bounds read in Media. Reported by Ameen Basha M K
    - CVE-2026-10999: Out of bounds memory access in ANGLE.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-11000: Use after free in Fonts.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-11001: Incorrect security UI in Payments. Reported by Google.
    - CVE-2026-11002: Use after free in Autofill.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-11003: Use after free in WebRTC.
      Reported by zh1x1an1221 of Ant Group Tianqiong Security Lab.
    - CVE-2026-11004: Out of bounds read in ANGLE.
      Reported by 86ac1f1587b71893ed2ad792cd7dde32.
    - CVE-2026-11005: Out of bounds read in ANGLE.
      Reported by 86ac1f1587b71893ed2ad792cd7dde32.
    - CVE-2026-11006: Out of bounds read in Dawn. Reported by Google.
    - CVE-2026-11007: Insufficient validation of untrusted input in WebView.
      Reported by Google.
    - CVE-2026-11008: Insufficient validation of untrusted input
      in WebAppInstalls. Reported by Google.
    - CVE-2026-11009: Use after free in USB. Reported by Google.
    - CVE-2026-11010: Use after free in WebShare. Reported by David Sievers.
    - CVE-2026-11011: Insufficient policy enforcement in Password Manager.
      Reported by Google.
    - CVE-2026-11012: Use after free in Serial. Reported by Google.
    - CVE-2026-11013: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-11014: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11015: Out of bounds read in WebGPU. Reported by Yuma Takeuchi.
    - CVE-2026-11016: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-11017: Inappropriate implementation in Link Preview.
      Reported by Google.
    - CVE-2026-11018: Insufficient policy enforcement in Actor.
      Reported by Google.
    - CVE-2026-11019: Inappropriate implementation in Payments.
      Reported by Google.
    - CVE-2026-11020: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-11021: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-11022: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-11023: Insufficient validation of untrusted input
      in WebAppInstalls. Reported by Google.
    - CVE-2026-11024: Stack buffer overflow in Skia. Reported by Google.
    - CVE-2026-11025: Insufficient policy enforcement in Navigation.
      Reported by Google.
    - CVE-2026-11026: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11027: Insufficient validation of untrusted input in Glic.
      Reported by Google.
    - CVE-2026-11028: Use after free in Media. Reported by Google.
    - CVE-2026-11029: Insufficient validation of untrusted input
      in Drag and Drop. Reported by Google.
    - CVE-2026-11030: Use after free in Network. Reported by Google.
    - CVE-2026-11031: Insufficient validation of untrusted input
      in Password Manager. Reported by Google.
    - CVE-2026-11032: Insufficient data validation in Password Manager.
      Reported by Google.
    - CVE-2026-11033: Uninitialized Use in WebML. Reported by Google.
    - CVE-2026-11034: Insufficient validation of untrusted input
      in Tab Group Sync. Reported by Google.
    - CVE-2026-11035: Insufficient validation of untrusted input
      in Custom Tabs. Reported by Google.
    - CVE-2026-11036: Inappropriate implementation in DOM. Reported by Google
    - CVE-2026-11037: Out of bounds write in Codecs. Reported by Google.
    - CVE-2026-11038: Insufficient validation of untrusted input
      in Subresource Integrity. Reported by Google.
    - CVE-2026-11039: Uninitialized Use in Skia. Reported by Google.
    - CVE-2026-11040: Use after free in ANGLE. Reported by Google.
    - CVE-2026-11041: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-11042: Use after free in Views. Reported by Google.
    - CVE-2026-11043: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-11044: Integer overflow in ANGLE. Reported by Google.
    - CVE-2026-11045: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-11046: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-11047: Insufficient validation of untrusted input in Base.
      Reported by Google.
    - CVE-2026-11048: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-11049: Use after free in Password Manager. Reported by Google.
    - CVE-2026-11050: Use after free in V8. Reported by Google.
    - CVE-2026-11051: Out of bounds read in ANGLE.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-11052: Type Confusion in GPU. Reported by Google.
    - CVE-2026-11053: VULNERABILITY in WebRTC. Reported by Google.
    - CVE-2026-11054: Use after free in WebRTC. Reported by Google.
    - CVE-2026-11055: Use after free in ANGLE. Reported by Google.
    - CVE-2026-11056: Insufficient validation of untrusted input
      in SiteIsolation. Reported by Google.
    - CVE-2026-11057: Uninitialized Use in Skia. Reported by Google.
    - CVE-2026-11058: Integer overflow in CredentialProvider.
      Reported by Google.
    - CVE-2026-11059: Use after free in Blink. Reported by Google.
    - CVE-2026-11060: Use after free in Media. Reported by Google.
    - CVE-2026-11061: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-11062: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11063: Insufficient validation of untrusted input in WebNN.
      Reported by Google.
    - CVE-2026-11064: Uninitialized Use in GPU. Reported by Google.
    - CVE-2026-11065: Use after free in ANGLE. Reported by Google.
    - CVE-2026-11066: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-11067: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-11068: Use after free in WebSockets. Reported by Google.
    - CVE-2026-11069: Insufficient validation of untrusted input in Cast.
      Reported by Google.
    - CVE-2026-11070: Insufficient validation of untrusted input in Chromoting
      Reported by Google.
    - CVE-2026-11071: Use after free in Base. Reported by Google.
    - CVE-2026-11072: Use after free in WebView. Reported by Google.
    - CVE-2026-11073: Use after free in WebGL. Reported by Google.
    - CVE-2026-11074: Use after free in WebRTC.
      Reported by boboliverfrancishoward@gmail.com.
    - CVE-2026-11075: Out of bounds read in V8.
      Reported by JunYoung Park(@candymate) of KAIST Hacking Lab.
    - CVE-2026-11076: Type Confusion in CSS. Reported by Google.
    - CVE-2026-11077: Out of bounds read in Dawn. Reported by Anonymous.
    - CVE-2026-11078: Insufficient validation of untrusted input
      in FileSystem. Reported by Eran Rom of Palo Alto Networks.
    - CVE-2026-11079: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-11080: Use after free in WebView. Reported by Google.
    - CVE-2026-11081: Policy bypass in Canvas. Reported by Google.
    - CVE-2026-11082: Use after free in GPU. Reported by Google.
    - CVE-2026-11083: Inappropriate implementation in Password Manager.
      Reported by Google.
    - CVE-2026-11084: Inappropriate implementation in Password Manager.
      Reported by Google.
    - CVE-2026-11085: Integer overflow in GPU. Reported by Google.
    - CVE-2026-11086: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-11087: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11088: Integer overflow in ANGLE. Reported by Google.
    - CVE-2026-11089: Uninitialized Use in Media. Reported by Google.
    - CVE-2026-11090: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11091: Inappropriate implementation in Dawn. Reported by Google
    - CVE-2026-11092: Insufficient policy enforcement in DevTools.
      Reported by Google.
    - CVE-2026-11093: Insufficient validation of untrusted input in Printing.
      Reported by Google.
    - CVE-2026-11094: Use after free in Codecs. Reported by Google.
    - CVE-2026-11095: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-11096: Out of bounds read in WebRTC. Reported by Google.
    - CVE-2026-11097: Inappropriate implementation in WebView.
      Reported by Google.
    - CVE-2026-11098: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-11099: Vulnerability in Skia. Reported by Google.
    - CVE-2026-11100: Use after free in File Input. Reported by Google.
    - CVE-2026-11101: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-11102: Inappropriate implementation in Isolated Web Apps.
      Reported by Google.
    - CVE-2026-11103: Inappropriate implementation in Installer.
      Reported by Google.
    - CVE-2026-11104: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11105: Insufficient validation of untrusted input in WebUI.
      Reported by Google.
    - CVE-2026-11106: Inappropriate implementation in Media.
      Reported by Google.
    - CVE-2026-11107: Inappropriate implementation in Downloads.
      Reported by Google.
    - CVE-2026-11108: Inappropriate implementation in NFC. Reported by Google
    - CVE-2026-11109: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11110: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11111: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-11112: Insufficient validation of untrusted input
      in Chromoting. Reported by Google.
    - CVE-2026-11113: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-11114: Use after free in Device Trust. Reported by Google.
    - CVE-2026-11115: Use after free in Updater. Reported by Google.
    - CVE-2026-11116: Use after free in Chromoting. Reported by Google.
    - CVE-2026-11117: Use after free in Views. Reported by Google.
    - CVE-2026-11118: Use after free in WebRTC. Reported by Google.
    - CVE-2026-11119: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-11120: Insufficient validation of untrusted input
      in Enterprise Reporting. Reported by Google.
    - CVE-2026-11121: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-11122: Inappropriate implementation in Keyboard.
      Reported by Google.
    - CVE-2026-11123: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11124: Heap buffer overflow in Skia. Reported by Google.
    - CVE-2026-11125: Use after free in Compositing. Reported by Google.
    - CVE-2026-11126: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-11127: Inappropriate implementation in WebAPKs.
      Reported by Google.
    - CVE-2026-11128: Insufficient validation of untrusted input
      in Web Share. Reported by Google.
    - CVE-2026-11129: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-11130: Use after free in Media. Reported by Google.
    - CVE-2026-11131: Use after free in Autofill. Reported by Google.
    - CVE-2026-11132: Policy bypass in Paint. Reported by Google.
    - CVE-2026-11133: Insufficient policy enforcement in Paint.
      Reported by Google.
    - CVE-2026-11134: Insufficient data validation in Media.
      Reported by Google.
    - CVE-2026-11135: Insufficient policy enforcement in Autofill.
      Reported by Google.
    - CVE-2026-11136: Use after free in Canvas.
      Reported by Jungwoo Lee (@physicube) and Wongi Lee (@_qwerty_po).
    - CVE-2026-11137: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11138: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11139: Policy bypass in Paint. Reported by Google.
    - CVE-2026-11140: Insufficient validation of untrusted input
      in Chromecast. Reported by Google.
    - CVE-2026-11141: Uninitialized Use in Audio. Reported by Google.
    - CVE-2026-11142: Policy bypass in Paint. Reported by Google.
    - CVE-2026-11143: Heap buffer overflow in Extensions. Reported by Google.
    - CVE-2026-11144: Use after free in Media. Reported by Google.
    - CVE-2026-11145: Race in Geolocation. Reported by Google.
    - CVE-2026-11146: Insufficient validation of untrusted input
      in Chromoting. Reported by Google.
    - CVE-2026-11147: Use after free in WebML. Reported by Google.
    - CVE-2026-11148: Inappropriate implementation in Payments.
      Reported by Google.
    - CVE-2026-11149: Insufficient validation of untrusted input
      in Extensions. Reported by Google.
    - CVE-2026-11150: Inappropriate implementation in XML. Reported by Google
    - CVE-2026-11151: Insufficient validation of untrusted input
      in Password Manager. Reported by Google.
    - CVE-2026-11152: Object lifecycle issue in Dawn. Reported by Google.
    - CVE-2026-11153: Side-channel information leakage in Forms.
      Reported by Google.
    - CVE-2026-11154: Use after free in Dawn. Reported by Google.
    - CVE-2026-11155: Insufficient policy enforcement in CSS.
      Reported by Google.
    - CVE-2026-11156: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-11157: Script injection in Accessibility. Reported by Google.
    - CVE-2026-11158: Insufficient validation of untrusted input in
      Downloads. Reported by Google.
    - CVE-2026-11159: Uninitialized Use in Skia. Reported by Google.
    - CVE-2026-11160: Out of bounds read in Input. Reported by Google.
    - CVE-2026-11161: Insufficient data validation in DataTransfer.
      Reported by Google.
    - CVE-2026-11162: Insufficient policy enforcement in CSS.
      Reported by Google.
    - CVE-2026-11163: Use after free in Messages. Reported by Google.
    - CVE-2026-11164: Use after free in Blink. Reported by Google.
    - CVE-2026-11165: Use after free in WebMIDI. Reported by Google.
    - CVE-2026-11166: Inappropriate implementation in SVG. Reported by Google
    - CVE-2026-11167: Inappropriate implementation in WebView.
      Reported by Google.
    - CVE-2026-11168: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11169: Inappropriate implementation in XML. Reported by Google
    - CVE-2026-11170: Inappropriate implementation in Chromoting.
      Reported by Google.
    - CVE-2026-11171: Integer overflow in Blink. Reported by Google.
    - CVE-2026-11172: Incorrect security UI in Contact Picker.
      Reported by mochazril.ti@gmail.com.
    - CVE-2026-11173: Out of bounds write in V8. Reported by Google.
    - CVE-2026-11174: Insufficient policy enforcement in Site Isolation.
      Reported by Google.
    - CVE-2026-11175: Incorrect security UI in Messages. Reported by Google.
    - CVE-2026-11176: Inappropriate implementation in Media.
      Reported by Google.
    - CVE-2026-11177: Use after free in Omnibox. Reported by gevakun.
    - CVE-2026-11178: Policy bypass in WebView. Reported by Google.
    - CVE-2026-11179: Inappropriate implementation in ORB. Reported by Google
    - CVE-2026-11180: Policy bypass in SVG. Reported by Google.
    - CVE-2026-11181: Inappropriate implementation in Media Session.
      Reported by Google.
    - CVE-2026-11182: Inappropriate implementation in SVG. Reported by Google
    - CVE-2026-11183: Out of bounds read in GWP-ASan. Reported by Google.
    - CVE-2026-11184: Insufficient policy enforcement in Actor.
      Reported by Google.
    - CVE-2026-11185: Use after free in V8. Reported by Google.
    - CVE-2026-11186: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-11187: Insufficient policy enforcement in Glic.
      Reported by Google.
    - CVE-2026-11188: Use after free in USB. Reported by Google.
    - CVE-2026-11189: Insufficient validation of untrusted input in DevTools.
      Reported by lebr0nli of National Yang Ming Chiao Tung University,
      Dept. of CS, Security and Systems Lab.
    - CVE-2026-11190: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11191: Out of bounds memory access in ANGLE.
      Reported by Google.
    - CVE-2026-11192: Insufficient validation of untrusted input
      in Password Manager. Reported by Google.
    - CVE-2026-11193: Insufficient policy enforcement in Password Manager.
      Reported by Google.
    - CVE-2026-11194: Inappropriate implementation in Network.
      Reported by Google.
    - CVE-2026-11195: Inappropriate implementation in MHTML.
      Reported by Google.
    - CVE-2026-11196: Type Confusion in XML. Reported by Google.
    - CVE-2026-11197: Insufficient policy enforcement in Workers.
      Reported by VEZEKA.
    - CVE-2026-11198: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-11199: Insufficient validation of untrusted input in WebRTC.
      Reported by Google.
    - CVE-2026-11200: Inappropriate implementation in WebRTC.
      Reported by Google.
    - CVE-2026-11201: Use after free in ServiceWorker.
      Reported by Weipeng Jiang (@Krace) of VRI.
    - CVE-2026-11202: Insufficient validation of untrusted input
      in Chrome for iOS. Reported by Google.
    - CVE-2026-11203: Policy bypass in GPU. Reported by Google.
    - CVE-2026-11204: Inappropriate implementation in Signin.
      Reported by Google.
    - CVE-2026-11205: Insufficient validation of untrusted input
      in Chrome for iOS. Reported by Google.
    - CVE-2026-11206: Policy bypass in ServiceWorker.
      Reported by David Bors, Catalin Iovita.
    - CVE-2026-11207: Insufficient validation of untrusted input in Autofill.
      Reported by Google.
    - CVE-2026-11208: Use after free in Codecs. Reported by Google.
    - CVE-2026-11209: Insufficient policy enforcement in Passwords.
      Reported by Google.
    - CVE-2026-11210: Insufficient policy enforcement in Safe Browsing.
      Reported by Google.
    - CVE-2026-11211: Integer overflow in V8. Reported by Google.
    - CVE-2026-11212: Insufficient policy enforcement in DevTools.
      Reported by Google.
    - CVE-2026-11213: Insufficient validation of untrusted input
      in Reading Mode. Reported by Google.
    - CVE-2026-11214: Inappropriate implementation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-11215: Inappropriate implementation in Cronet.
      Reported by Google.
    - CVE-2026-11216: Incorrect security UI in File Input.
      Reported by Azza Tegar Naufal Ataullah.
    - CVE-2026-11217: Insufficient policy enforcement in Fenced Frames.
      Reported by Tianyi Hu.
    - CVE-2026-11218: Inappropriate implementation in PlatformIntegration.
      Reported by Han Liu (Xi’an Jiaotong University, School of
      Cyber Science and Engineering).
    - CVE-2026-11219: Insufficient data validation in Navigation.
      Reported by Bharat (mrnoob) .
    - CVE-2026-11220: Insufficient validation of untrusted input in
      Navigation. Reported by Tianyi Hu.
    - CVE-2026-11221: Insufficient validation of untrusted input
      in PointerLock. Reported by mihalis.haatainen@bountyy.fi.
    - CVE-2026-11222: Incorrect security UI in Tab Strip. Reported by Hafiizh
    - CVE-2026-11223: Insufficient validation of untrusted input in Network.
      Reported by Tianyi Hu.
    - CVE-2026-11224: Use after free in Chromoting.
      Reported by David Bors, Catalin Iovita.
    - CVE-2026-11225: Incorrect security UI in WebUI.
      Reported by Tareq Ahamed - itztrq.
    - CVE-2026-11226: Insufficient policy enforcement in PreviewTab.
      Reported by Google.
    - CVE-2026-11227: Incorrect security UI in Tab Hover Cards.
      Reported by Hafiizh.
    - CVE-2026-11228: Incorrect security UI in File Input.
      Reported by Umar Farooq .
    - CVE-2026-11229: Insufficient policy enforcement in Enterprise.
      Reported by Povcfe of Tencent Security Xuanwu Lab.
    - CVE-2026-11230: Use after free in Extensions. Reported by Google.
    - CVE-2026-11231: Inappropriate implementation in Safe Browsing.
      Reported by Google.
    - CVE-2026-11232: Inappropriate implementation in TabGroups.
      Reported by Google.
    - CVE-2026-11233: Insufficient validation of untrusted input in
      FoldableAPIs. Reported by Google.
    - CVE-2026-11234: Insufficient policy enforcement in FoldableAPIs.
      Reported by Google.
    - CVE-2026-11235: Insufficient validation of untrusted input
      in Compositing. Reported by Google.
    - CVE-2026-11236: Insufficient policy enforcement in Web Bluetooth.
      Reported by Google.
    - CVE-2026-11237: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-11238: Inappropriate implementation in DevTools.
      Reported by Google.
    - CVE-2026-11239: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-11240: Insufficient validation of untrusted input in Loader.
      Reported by Google.
    - CVE-2026-11241: Insufficient validation of untrusted input in Cast.
      Reported by Google.
    - CVE-2026-11242: Insufficient validation of untrusted input in Plugins.
      Reported by Google.
    - CVE-2026-11243: Incorrect security UI in Downloads. Reported by Google.
    - CVE-2026-11244: Insufficient validation of untrusted input in
      WebAuthentication. Reported by Google.
    - CVE-2026-11245: Inappropriate implementation in Payments.
      Reported by Google.
    - CVE-2026-11246: Insufficient validation of untrusted input in
      IndexedDB. Reported by Google.
    - CVE-2026-11247: Insufficient policy enforcement in CustomTabs.
      Reported by Google.
    - CVE-2026-11248: Policy bypass in Google Lens. Reported by Google.
    - CVE-2026-11249: Use after free in Network. Reported by Google.
    - CVE-2026-11250: Inappropriate implementation in DevTools.
      Reported by Google.
    - CVE-2026-11251: Insufficient validation of untrusted input in
      Password Manager. Reported by Google.
    - CVE-2026-11252: Policy bypass in Content Settings. Reported by Google.
    - CVE-2026-11253: Race in Permissions. Reported by Google.
    - CVE-2026-11254: Inappropriate implementation in Permissions.
      Reported by Google.
    - CVE-2026-11255: Insufficient validation of untrusted input in
      Storage Access API. Reported by Google.
    - CVE-2026-11256: Out of bounds read in GPU. Reported by Google.
    - CVE-2026-11257: Inappropriate implementation in Browser.
      Reported by Google.
    - CVE-2026-11258: Inappropriate implementation in File System Access.
      Reported by Google.
    - CVE-2026-11259: Insufficient validation of untrusted input in Cast.
      Reported by Google.
    - CVE-2026-11260: Policy bypass in Permissions. Reported by Google.
    - CVE-2026-11261: Insufficient validation of untrusted input in PDF.
      Reported by Google.
    - CVE-2026-11262: Use after free in TabStrip. Reported by Google.
    - CVE-2026-11263: Insufficient policy enforcement in WebAuthentication.
      Reported by Google.
    - CVE-2026-11264: Policy bypass in Content Security Policy.
      Reported by Google.
    - CVE-2026-11265: Insufficient data validation in Autofill.
      Reported by Google.
    - CVE-2026-11266: Policy bypass in SafeBrowsing. Reported by Google.
    - CVE-2026-11267: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-11268: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-11269: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-11270: Inappropriate implementation in UI. Reported by Google.
    - CVE-2026-11271: Incorrect security UI in Passwords. Reported by Google.
    - CVE-2026-11272: Insufficient validation of untrusted input in
      Reading List. Reported by Google.
    - CVE-2026-11273: Insufficient validation of untrusted input in Omnibox.
      Reported by Google.
    - CVE-2026-11274: Inappropriate implementation in DOM Distiller.
      Reported by Google.
    - CVE-2026-11275: Insufficient policy enforcement in Page Info.
      Reported by Google.
    - CVE-2026-11276: Inappropriate implementation in Cast. Reported by Google
    - CVE-2026-11277: Insufficient policy enforcement in Chrome for iOS.
      Reported by Google.
    - CVE-2026-11278: Inappropriate implementation in CustomTabs.
      Reported by Google.
    - CVE-2026-11279: Out of bounds read in DevTools. Reported by Google.
    - CVE-2026-11280: Insufficient validation of untrusted input in Signin.
      Reported by Google.
    - CVE-2026-11281: Integer overflow in Chromoting. Reported by Google.
    - CVE-2026-11282: Policy bypass in Sandbox. Reported by Google.
    - CVE-2026-11283: Policy bypass in Shortcuts. Reported by Google.
    - CVE-2026-11284: Side-channel information leakage in PerformanceAPIs.
      Reported by Google.
    - CVE-2026-11285: Insufficient policy enforcement in Chrome for iOS.
      Reported by Google.
    - CVE-2026-11286: Insufficient validation of untrusted input in Wallet.
      Reported by Google.
    - CVE-2026-11287: Insufficient validation of untrusted input in
      Navigation. Reported by Google.
    - CVE-2026-11288: Policy bypass in CSS. Reported by Google.
    - CVE-2026-11289: Side-channel information leakage in Paint.
      Reported by Google.
    - CVE-2026-11290: Integer overflow in WebView. Reported by Google.
    - CVE-2026-11291: Policy bypass in Android Autofill. Reported by Google.
    - CVE-2026-11292: Policy bypass in Blink. Reported by Google.
    - CVE-2026-11293: Use after free in Input.
      Reported by Weipeng Jiang (@Krace) of VRI.
    - CVE-2026-11294: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-11295: Inappropriate implementation in WebView.
      Reported by Google.
    - CVE-2026-11296: Inappropriate implementation in ImageCapture.
      Reported by Google.
    - CVE-2026-11297: Insufficient validation of untrusted input in
      Reader Mode. Reported by Google.
    - CVE-2026-11298: Insufficient policy enforcement in Chrome for iOS.
      Reported by Google.
    - CVE-2026-11299: Out of bounds read in Fonts.
      Reported by sharadboni@gmail.com.
    - CVE-2026-11300: Inappropriate implementation in Permissions.
      Reported by Google.
    - CVE-2026-11301: Out of bounds read in LiveCaption. Reported by Google.
    - CVE-2026-11302: Insufficient policy enforcement in Chrome for iOS.
      Reported by Google.
    - CVE-2026-11303: Use after free in PDFium. Reported by Google.
    - CVE-2026-11304: Use after free in PDFium. Reported by Google.
    - CVE-2026-11305: Use after free in PDFium. Reported by Google.
    - CVE-2026-11306: Use after free in PDFium. Reported by Google.
    - CVE-2026-11307: Use after free in PDFium. Reported by Google.
    - CVE-2026-11308: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-11309: Insufficient policy enforcement in History.
      Reported by Google.
  * d/patches:
    - upstream/turboshaft.patch: drop, merged upstream.
    - fixes/enable-widevine-on-arm64-linux-platform.patch: drop, merged
      upstream.
    - debianization/clang-version.patch: refresh.
    - fixes/armhf-icf.patch: refresh.
    - disable/catapult.patch: refresh.
    - llvm-19/clang19.patch: add more bits to drop unsupported warning and
      diagnostic flags.
    - trixie/gn-inputs.patch: drop portion of patch due to upstream changes.
    - trixie/gn-inputs2.patch: refresh.
    - bookworm/bindgen.patch: drop due to upgraded bindgen [sid, trixie].
    - bookworm/gn-allowlist.patch: drop due to upgraded generate-ninja [sid,
      trixie].
    - llvm-22/ignore-for-ubsan.patch: update for upstream reworking.
    - ungoogled/disable-ai.patch: sync from u-c.
    - ungoogled/disable-privacy-sandbox.patch: sync from u-c.
    - ungoogled/remove-navigation-source-param.patch: sync from u-c.
    - trixie/gn-expand-dir-allowlist.patch: add new patch to work around
      older generate-ninja.
    - fixes/libcpp-headers.patch: update for upstream changes reworking how
      this was done.
    - disable/libei.patch: add patch to fix build failure due to libei
      removal.
    - llvm-19/value-or.patch: add another clang-19 build workaround.
    - llvm-19/const-profile.patch: add patch to work around const-related
      clang-19 build failure.
    - rust-1.85/file_as_c_str.patch: rework patch due to upstream changes
      [trixie, bookworm].
    - rust-1.85/zip8.patch: refresh [trixie, bookworm].
    - bookworm/dav1d-drop-hdr.patch: refresh [bookworm].
  * d/copyright: properly delete harfbuzz (due to harfbuzz-ng rename).

  [ Daniel Richard G. ]
  * d/patches:
    - bookworm/bindgen.patch: Refresh [bookworm].
    - bookworm/gn-absl.patch: Update absl_source_set("no_destructor") with
      visibility directive, and refresh [bookworm].
    - rust-1.85/mojo-features.patch: Add feature to new Rust source file
      [trixie, bookworm].

  [ Timothy Pearson ]
  * d/patches/ppc64le:
    - third_party/0002-third_party-libvpx-Remove-bad-ppc64-config.patch:
      refresh for upstream changes
    - third_party/0002-regenerate-xnn-buildgn.patch: refresh for upstream
      changes
    - third_party/0005-blink-add-audio-vector-support.patch: refresh for
      upstream changes
    - libaom/0001-Add-pregenerated-config-for-libaom-on-ppc64.patch: regenerate
    - third_party/0003-third_party-libvpx-Add-ppc64-generated-config.patch:
      regenerate
    - third_party/0001-third_party-libvpx-Disable-vsx-on-ppc64.patch: ensure
      VSX is disabled until VP9 artifacting can be fixed upstream

  [ Jianfeng Liu ]
  * d/patches:
    - upstream/0001-Fix-build-for-CPU-yield-on-LoongArch.patch: This is a
      patch aleady merged to v150 to fix build on loongarch64.
    - loongarch64/0024-fix-libyuv-lsx.patch: Upstream has bumped the version
      of libyuv and it has broken build with lsx enabled on loongarch64. Add
      a patch to fix the build first.

 -- Andres Salomon <dilinger@debian.org>  Sat, 06 Jun 2026 04:19:15 -0400

chromium (148.0.7778.215-2) unstable; urgency=high

  [ Juan Manuel Méndez Rey ]
  * Team upload.
  * d/patches/fixes/bytemuck.patch: select bytemuck's core::simd impls by rust
    version rather than date, fixing FTBFS with rustc 1.95 (which removed
    core::simd::LaneCount) while still building on rust < 1.95
    (trixie/bookworm). Affects the default chromium build too.

 -- Juan Manuel Méndez Rey <vejeta@gmail.com>  Mon, 01 Jun 2026 17:06:05 +0200

chromium (148.0.7778.215-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE-2026-9872: Out of bounds write in GPU. Reported by cinzinga.
    - CVE-2026-9873: Use after free in Network. Reported by cinzinga.
    - CVE-2026-9874: Use after free in Dawn. Reported by Anonymous.
    - CVE-2026-9875: Out of bounds read in WebGL. Reported by Anonymous.
    - CVE-2026-9876: Use after free in WebGL. Reported by happy2me.
    - CVE-2026-9877: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9878: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9879: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-9880: Insufficient validation of untrusted input in WebGL.
      Reported by Google.
    - CVE-2026-9881: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-9882: Integer overflow in ANGLE. Reported by Google.
    - CVE-2026-9883: Use after free in Base. Reported by Google.
    - CVE-2026-9884: Use after free in Browser. Reported by Google.
    - CVE-2026-9885: Insufficient validation of untrusted input in UI.
      Reported by Google.
    - CVE-2026-9886: Use after free in Base. Reported by Google.
    - CVE-2026-9887: Use after free in Proxy. Reported by Google.
    - CVE-2026-9888: Use after free in WebView. Reported by Google.
    - CVE-2026-9889: Out of bounds read and write in Dawn. Reported by Google.
    - CVE-2026-9890: Use after free in XR. Reported by Google.
    - CVE-2026-9891: Use after free in Extensions. Reported by Google.
    - CVE-2026-9892: Inappropriate implementation in Skia. Reported by Google.
    - CVE-2026-9893: Use after free in Skia. Reported by Google.
    - CVE-2026-9894: Use after free in GPU. Reported by tohafrit.
    - CVE-2026-9895: Out of bounds read in GPU.
      Reported by 86ac1f1587b71893ed2ad792cd7dde32.
    - CVE-2026-9896: Out of bounds write in V8. Reported by 303f06e3.
    - CVE-2026-9897: Use after free in DOM. Reported by Google.
    - CVE-2026-9898: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-9899: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9900: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-9901: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9902: Use after free in Accessibility. Reported by Google.
    - CVE-2026-9903: Insufficient validation of untrusted input in
      Site Isolation. Reported by Google.
    - CVE-2026-9904: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9905: Use after free in Accessibility. Reported by Google.
    - CVE-2026-9906: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-9907: Out of bounds read in Dawn. Reported by Google.
    - CVE-2026-9908: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-9909: Integer overflow in Skia. Reported by Google.
    - CVE-2026-9910: Out of bounds memory access in ANGLE. Reported by Google.
    - CVE-2026-9911: Integer overflow in ANGLE. Reported by Google.
    - CVE-2026-9912: Inappropriate implementation in GPU. Reported by Google.
    - CVE-2026-9913: Inappropriate implementation in ANGLE. Reported by Google
    - CVE-2026-9914: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-9915: Heap buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-9916: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-9917: Uninitialized Use in WebGL. Reported by Google.
    - CVE-2026-9918: Inappropriate implementation in Tint. Reported by Google.
    - CVE-2026-9919: Out of bounds read in WebGL. Reported by Google.
    - CVE-2026-9920: Uninitialized Use in GPU. Reported by Google.
    - CVE-2026-9921: Uninitialized Use in WebGL. Reported by Google.
    - CVE-2026-9922: Use after free in GPU. Reported by Google.
    - CVE-2026-9923: Use after free in Skia. Reported by Google.
    - CVE-2026-9924: Heap buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-9925: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9926: Heap buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-9927: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9928: Out of bounds read in ANGLE.
      Reported by Jeff Muizelaar - Mozilla.
    - CVE-2026-9929: Inappropriate implementation in WebGL. Reported by Google
    - CVE-2026-9930: Out of bounds write in Dawn. Reported by Google.
    - CVE-2026-9931: Use after free in GPU. Reported by Google.
    - CVE-2026-9932: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9933: Use after free in Input. Reported by Google.
    - CVE-2026-9934: Use after free in Aura. Reported by Google.
    - CVE-2026-9935: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-9936: Use after free in GFX. Reported by Google.
    - CVE-2026-9937: Use after free in UI. Reported by Google.
    - CVE-2026-9938: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-9939: Heap buffer overflow in WebCodecs. Reported by Google.
    - CVE-2026-9940: Heap buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-9941: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9942: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-9943: Out of bounds read in WebGL. Reported by Google.
    - CVE-2026-9944: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-9945: Use after free in Media. Reported by Google.
    - CVE-2026-9946: Use after free in ANGLE. Reported by Google.
    - CVE-2026-9947: Use after free in XML. Reported by Google.
    - CVE-2026-9948: Use after free in Views. Reported by Google.
    - CVE-2026-9949: Use after free in Core. Reported by Google.
    - CVE-2026-9950: Insufficient validation of untrusted input in iOS.
      Reported by Google.
    - CVE-2026-9951: Use after free in UI. Reported by Google.
    - CVE-2026-9952: Use after free in WebAudio. Reported by Google.
    - CVE-2026-9953: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-9954: Use after free in TabStrip.
      Reported by yueliu of Microsoft.
    - CVE-2026-9955: Inappropriate implementation in iOS. Reported by Google.
    - CVE-2026-9956: Use after free in iOS. Reported by Google.
    - CVE-2026-9957: Use after free in PDF. Reported by Google.
    - CVE-2026-9958: Use after free in PDFium. Reported by Google.
    - CVE-2026-9959: Race in WebRTC. Reported by Google.
    - CVE-2026-9960: Integer overflow in PDFium. Reported by Google.
    - CVE-2026-9961: Use after free in SurfaceCapture. Reported by Google.
    - CVE-2026-9962: Use after free in WebRTC. Reported by Google.
    - CVE-2026-9963: Uninitialized Use in iOS. Reported by Google.
    - CVE-2026-9964: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-9965: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-9966: Integer overflow in XML. Reported by Google.
    - CVE-2026-9967: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-9968: Integer overflow in V8. Reported by Google.
    - CVE-2026-9969: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-9970: Use after free in WebGL. Reported by TFGC.
    - CVE-2026-9971: Inappropriate implementation in iOS. Reported by Google.
    - CVE-2026-9972: Uninitialized Use in Gamepad. Reported by Google.
    - CVE-2026-9973: Out of bounds write in V8. Reported by amyb of OpenAI.
    - CVE-2026-9974: Out of bounds write in GPU. Reported by Google.
    - CVE-2026-9975: Out of bounds read and write in ANGLE. Reported by Google
    - CVE-2026-9976: Inappropriate implementation in USB. Reported by Google.
    - CVE-2026-9977: Insufficient validation of untrusted input in WebShare.
      Reported by Google.
    - CVE-2026-9978: Use after free in Glic. Reported by Google.
    - CVE-2026-9979: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-9980: Insufficient validation of untrusted input in Printing.
      Reported by Google.
    - CVE-2026-9981: Inappropriate implementation in Skia. Reported by Google.
    - CVE-2026-9982: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-9983: Type Confusion in Skia. Reported by Google.
    - CVE-2026-9984: Use after free in UI. Reported by Google.
    - CVE-2026-9985: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-9986: Insufficient validation of untrusted input in
      OptimizationGuide. Reported by Google.
    - CVE-2026-9987: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-9988: Use after free in WebRTC. Reported by Google.
    - CVE-2026-9989: Inappropriate implementation in Media. Reported by Google
    - CVE-2026-9990: Use after free in WebAppInstalls. Reported by Google.
    - CVE-2026-9991: Inappropriate implementation in Media. Reported by Google
    - CVE-2026-9992: Use after free in Network. Reported by Google.
    - CVE-2026-9993: Use after free in Views. Reported by Google.
    - CVE-2026-9994: Use after free in Core. Reported by Google.
    - CVE-2026-9995: Use after free in WebXR. Reported by Google.
    - CVE-2026-9996: Out of bounds read in WebRTC. Reported by Google.
    - CVE-2026-9997: Use after free in Input. Reported by Google.
    - CVE-2026-9998: Integer overflow in Skia. Reported by Google.
    - CVE-2026-9999: Inappropriate implementation in ANGLE. Reported by Google
    - CVE-2026-10000: Use after free in Passwords. Reported by Google.
    - CVE-2026-10001: Use after free in PerformanceManager. Reported by Google
    - CVE-2026-10002: Use after free in PDFium. Reported by Google.
    - CVE-2026-10003: Use after free in Views. Reported by Google.
    - CVE-2026-10004: Insufficient validation of untrusted input in Passwords.
      Reported by Google.
    - CVE-2026-10005: Use after free in WebAppInstalls. Reported by Google.
    - CVE-2026-10006: Race in WebAudio. Reported by Google.
    - CVE-2026-10007: Use after free in SVG. Reported by Google.
    - CVE-2026-10008: Uninitialized Use in GPU. Reported by Google.
    - CVE-2026-10009: Integer overflow in Skia. Reported by Google.
    - CVE-2026-10010: Inappropriate implementation in Input.
      Reported by Google.
    - CVE-2026-10011: Inappropriate implementation in Skia. Reported by Google
    - CVE-2026-10012: Use after free in Skia. Reported by Google.
    - CVE-2026-10013: Use after free in WebCodecs. Reported by Google.
    - CVE-2026-10014: Use after free in WebMIDI. Reported by Google.
    - CVE-2026-10015: Integer overflow in WTF. Reported by Google.
    - CVE-2026-10016: Use after free in DOM. Reported by pwn2addr.
    - CVE-2026-10017: Out of bounds read in Headless.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-10018: Integer overflow in ANGLE. Reported by Rahul Raj.
    - CVE-2026-10019: Integer overflow in ANGLE.
      Reported by Mufeed VH from Winfunc Research (winfunc.com).
    - CVE-2026-10020: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-10021: Insufficient validation of untrusted input in USB.
      Reported by Google.
    - CVE-2026-10022: Type Confusion in V8. Reported by ggwhyp.

 -- Andres Salomon <dilinger@debian.org>  Fri, 29 May 2026 11:48:56 -0400

chromium (148.0.7778.178-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE-2026-9111: Use after free in WebRTC. Reported by Google.
    - CVE-2026-9110: Inappropriate implementation in UI. Reported by Google.
    - CVE-2026-9112: Use after free in GPU.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-9113: Out of bounds read in GPU.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-9114: Use after free in QUIC. Reported by Google.
    - CVE-2026-9115: Insufficient policy enforcement in Service Worker.
      Reported by Google.
    - CVE-2026-9116: Insufficient policy enforcement in ServiceWorker.
      Reported by Google.
    - CVE-2026-9117: Type Confusion in GFX. Reported by Google.
    - CVE-2026-9118: Use after free in XR. Reported by Google.
    - CVE-2026-9119: Heap buffer overflow in WebRTC. Reported by Google.
    - CVE-2026-9120: Use after free in WebRTC. Reported by Google.
    - CVE-2026-9126: Use after free in DOM. Reported by Google.
    - CVE-2026-9121: Out of bounds read in GPU.
      Reported by David Korczynski (Adalogics) .
    - CVE-2026-9122: Out of bounds read in GPU.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-9123: Heap buffer overflow in Chromecast. Reported by Google.
    - CVE-2026-9124: Insufficient validation of untrusted input in Input.
      Reported by Google.
```