### PR TITLE
Docker: Update Chromium to 149.0.7827.114

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-06-11' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-06-16' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=149.0.7827.102
+ARG CHROMIUM_VERSION=149.0.7827.114
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Addresses:
- CVE-2026-12007
- CVE-2026-12008
- CVE-2026-12009
- CVE-2026-12010
- CVE-2026-12011
- CVE-2026-12012
- CVE-2026-12013
- CVE-2026-12014
- CVE-2026-12015
- CVE-2026-12016
- CVE-2026-12017
- CVE-2026-12018
- CVE-2026-12019
- CVE-2026-12020
- CVE-2026-12022
- CVE-2026-12023
- CVE-2026-12024
- CVE-2026-12025
- CVE-2026-12026
- CVE-2026-12027
- CVE-2026-12028
- CVE-2026-12029
- CVE-2026-12030
- CVE-2026-12031
- CVE-2026-12032
- CVE-2026-12033
- CVE-2026-12034
- CVE-2026-12035