### PR TITLE
Docker: Update Chromium to 149.0.7827.155

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-06-16' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-06-19' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=149.0.7827.114
+ARG CHROMIUM_VERSION=149.0.7827.155
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
From Debian's changelog:

```
chromium (149.0.7827.155-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE-2026-12437: Use after free in WebShare. Reported by Google.
    - CVE-2026-12438: Inappropriate implementation in WebView.
      Reported by Google.
    - CVE-2026-12439: Use after free in Digital Credentials.
      Reported by Google.
    - CVE-2026-12440: Use after free in DigitalCredentials. Reported by Google
    - CVE-2026-12441: Use after free in File Input. Reported by Google.
    - CVE-2026-12442: Use after free in Passwords. Reported by Google.
    - CVE-2026-12443: Use after free in Web Authentication. Reported by Google
    - CVE-2026-12444: Out of bounds read in Chromoting. Reported by Google.
    - CVE-2026-12445: Use after free in Extensions. Reported by Google.
    - CVE-2026-12446: Insufficient data validation in Passwords.
      Reported by Google.
    - CVE-2026-12447: Heap buffer overflow in WebRTC. Reported by Google.
    - CVE-2026-12448: Inappropriate implementation in WebView.
      Reported by Google.
    - CVE-2026-12449: Use after free in Chromoting. Reported by Google.
    - CVE-2026-12450: Inappropriate implementation in Media.
      Reported by Zhixin Tu.
    - CVE-2026-12451: Use after free in DigitalCredentials. Reported by Google
    - CVE-2026-12452: Use after free in Downloads. Reported by Google.
    - CVE-2026-12453: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-12454: Race in Safe Browsing. Reported by Google.
    - CVE-2026-12455: Use after free in Tab Strip. Reported by Google.
    - CVE-2026-12456: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-12457: Insufficient data validation in Extensions.
      Reported by Google.
    - CVE-2026-12458: Incorrect security UI in Passwords. Reported by Google.
    - CVE-2026-12459: Inappropriate implementation in Serial.
      Reported by Google.
    - CVE-2026-12460: Insufficient policy enforcement in File System Access.
      Reported by Google.
    - CVE-2026-12461: Out of bounds read in WebRTC. Reported by Google.
    - CVE-2026-12462: Use after free in Media. Reported by Google.
    - CVE-2026-12463: Inappropriate implementation in Views.
      Reported by Google.
    - CVE-2026-12464: Use after free in Browser. Reported by Google.
    - CVE-2026-12465: Insufficient validation of untrusted input in Metrics.
      Reported by Google.
    - CVE-2026-12466: Heap buffer overflow in WebRTC. Reported by Google.
    - CVE-2026-12467: Use after free in Extensions. Reported by Google.
    - CVE-2026-12468: Inappropriate implementation in Updater.
      Reported by Google.
    - CVE-2026-12469: Uninitialized Use in GPU. Reported by Google.
```