### PR TITLE
Docker: Update Chromium to 150.0.7871.100

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-06-29' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-07-09' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=149.0.7827.196
+ARG CHROMIUM_VERSION=150.0.7871.100
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Changelog from Debian:

```
chromium (150.0.7871.100-1) unstable; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE list still to be announced.
  * debian/patches/ungoogled/remove-navigation-source-param.patch: fix crash
    related to the previous version's resynch. Thanks to
    plmaneo <plmaneo@agent.qq.com> for the suggested patch (closes: #1141488).

 -- Andres Salomon <dilinger@debian.org>  Tue, 07 Jul 2026 13:47:51 -0400

chromium (150.0.7871.46-1) unstable; urgency=high

  [ Andres Salomon ]
  * New upstream stable release.
    - CVE-2026-13774: Use after free in Extensions. Reported by Google.
    - CVE-2026-13775: Use after free in GPU. Reported by Google.
    - CVE-2026-14398: Use after free in ANGLE. Reported by Google.
    - CVE-2026-13776: Type Confusion in Dawn. Reported by Google.
    - CVE-2026-13777: Insufficient validation of untrusted input in iOSWeb.
      Reported by Google.
    - CVE-2026-13778: Use after free in WebUSB. Reported by Google.
    - CVE-2026-13779: Use after free in Chromoting. Reported by Google.
    - CVE-2026-13780: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-13781: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-14417: Use after free in Dawn. Reported by Google.
    - CVE-2026-13782: Use after free in Browser. Reported by Google.
    - CVE-2026-13783: Use after free in Views. Reported by Google.
    - CVE-2026-13784: Use after free in Views. Reported by Google.
    - CVE-2026-14419: Use after free in Skia. Reported by Google.
    - CVE-2026-13785: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-14420: Out of bounds read and write in Dawn.
      Reported by Google.
    - CVE-2026-13786: Use after free in Ozone. Reported by Google.
    - CVE-2026-14427: Heap buffer overflow in Skia. Reported by Google.
    - CVE-2026-13787: Use after free in Chromoting. Reported by Google.
    - CVE-2026-13788: Use after free in Fullscreen. Reported by Google.
    - CVE-2026-14382: Insufficient validation of untrusted input in ANGLE.
      Reported by anonymous.
    - CVE-2026-13790: Side-channel information leakage in Scroll.
      Reported by Vsevolod Kokorin (Slonser) of Solidlab and Jorian Woltjer.
    - CVE-2026-14385: Heap buffer overflow in ANGLE.
      Reported by Thomas Guillem <thomas@gllm.fr>.
    - CVE-2026-13791: Insufficient validation of untrusted input in
      Downloads. Reported by Ron Masas (Imperva).
    - CVE-2026-13792: Use after free in Touchbar.
      Reported by Weipeng Jiang (@Krace) of VRI.
    - CVE-2026-13793: Insufficient policy enforcement in SVG.
      Reported by pakhunov.anton.n@gmail.com.
    - CVE-2026-14392: Out of bounds write in Tint.
      Reported by FastPL Group, Imperial College London.
    - CVE-2026-13794: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Daniel Rodríguez.
    - CVE-2026-14422: Out of bounds read and write in Tint.
      Reported by Michal Andryskowski.
    - CVE-2026-13795: Insufficient policy enforcement in Chrome for iOS.
      Reported by maitai.
    - CVE-2026-14426: Use after free in V8. Reported by ywatanabee.
    - CVE-2026-13796: Integer overflow in Chromecast. Reported by Google.
    - CVE-2026-13797: Insufficient validation of untrusted input in
      Chromecast. Reported by Google.
    - CVE-2026-14386: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-13798: Heap buffer overflow in Chromecast. Reported by Google.
    - CVE-2026-13799: Use after free in QUIC. Reported by Google.
    - CVE-2026-13800: Inappropriate implementation in Updater.
      Reported by Google.
    - CVE-2026-13801: Integer overflow in Chromecast. Reported by Google.
    - CVE-2026-13802: Use after free in Views. Reported by Google.
    - CVE-2026-13803: Type Confusion in Chrome Tabs. Reported by Google.
    - CVE-2026-13804: Use after free in Chromecast. Reported by Google.
    - CVE-2026-13805: Use after free in GFX. Reported by Google.
    - CVE-2026-14390: Use after free in ANGLE. Reported by Google.
    - CVE-2026-13806: Insufficient validation of untrusted input in
      Accessibility. Reported by Google.
    - CVE-2026-13807: Use after free in Import. Reported by Google.
    - CVE-2026-13808: Insufficient data validation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13809: Side-channel information leakage in Safe Browsing.
      Reported by Google.
    - CVE-2026-13810: Inappropriate implementation in Input.
      Reported by dilipsc03@gmail.com.
    - CVE-2026-13811: Use after free in IME. Reported by Google.
    - CVE-2026-13812: Insufficient validation of untrusted input in
      Chrome for iOS. Reported by Google.
    - CVE-2026-13813: Insufficient validation of untrusted input in
      Chrome for iOS. Reported by Google.
    - CVE-2026-13814: Use after free in Views. Reported by Google.
    - CVE-2026-13815: Use after free in Blink. Reported by Google.
    - CVE-2026-13816: Insufficient validation of untrusted input in File
      Input. Reported by Google.
    - CVE-2026-14396: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-13817: Insufficient validation of untrusted input in Glic.
      Reported by Google.
    - CVE-2026-13818: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-13819: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-13820: Out of bounds read in Skia. Reported by Google.
    - CVE-2026-14400: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-14401: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-14402: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-13821: Use after free in Canvas. Reported by Google.
    - CVE-2026-13822: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-13823: Use after free in Glic. Reported by Google.
    - CVE-2026-13824: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-13825: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-13826: Inappropriate implementation in Autofill.
      Reported by Google.
    - CVE-2026-13827: Use after free in Updater. Reported by Google.
    - CVE-2026-13828: Inappropriate implementation in Enterprise.
      Reported by Google.
    - CVE-2026-13829: Insufficient validation of untrusted input in Settings.
      Reported by Google.
    - CVE-2026-13830: Use after free in Chromoting. Reported by Google.
    - CVE-2026-13831: Use after free in GPU. Reported by Google.
    - CVE-2026-13832: Use after free in Headless. Reported by Google.
    - CVE-2026-14411: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-13833: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-14412: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-14413: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-13834: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-13835: Inappropriate implementation in XML. Reported by Google.
    - CVE-2026-13836: Inappropriate implementation in CSS. Reported by Google.
    - CVE-2026-13837: Inappropriate implementation in CSS. Reported by Google.
    - CVE-2026-13838: Inappropriate implementation in CSS. Reported by Google.
    - CVE-2026-13839: Inappropriate implementation in CSS. Reported by Google.
    - CVE-2026-13840: Insufficient policy enforcement in Canvas.
      Reported by Binglin Song.
    - CVE-2026-13841: Integer overflow in Skia. Reported by Google.
    - CVE-2026-13842: Incorrect security UI in Chrome for iOS.
      Reported by Azza Tegar Naufal Ataullah.
    - CVE-2026-14418: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-13843: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-13844: Use after free in Updater. Reported by Google.
    - CVE-2026-13845: Use after free in DOM. Reported by Google.
    - CVE-2026-13846: Use after free in USB. Reported by Google.
    - CVE-2026-13847: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-13848: Use after free in Forms. Reported by Google.
    - CVE-2026-13849: Insufficient validation of untrusted input in
      Chromoting. Reported by Google.
    - CVE-2026-14423: Type Confusion in Tint. Reported by Google.
    - CVE-2026-13850: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-14424: Use after free in Dawn. Reported by Google.
    - CVE-2026-14425: Use after free in ANGLE. Reported by Google.
    - CVE-2026-13851: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-14428: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-14429: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-14430: Integer overflow in V8. Reported by Google.
    - CVE-2026-13852: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-13853: Use after free in Journeys. Reported by Google.
    - CVE-2026-13854: Use after free in Ozone. Reported by Google.
    - CVE-2026-14431: Type Confusion in V8.
      Reported by OpenAI Codex Security (amyb).
    - CVE-2026-13855: Use after free in Ozone. Reported by Google.
    - CVE-2026-13856: Insufficient validation of untrusted input in Speech.
      Reported by c6eed09fc8b174b0f3eebedcceb1e792.
    - CVE-2026-13857: Inappropriate implementation in Geometry.
      Reported by Luan Herrera (@lbherrera_).
    - CVE-2026-13858: Out of bounds read in FFmpeg. Reported by Wongi Lee
      (@_qwerty_po) of Theori with Xint Code, Jungwoo Lee (@physicube).
    - CVE-2026-13859: Inappropriate implementation in ANGLE.
      Reported by Jason Villaluna.
    - CVE-2026-14391: Integer overflow in ANGLE. Reported by Quac Tran.
    - CVE-2026-13860: Incorrect security UI in Autofill.
      Reported by Khalil Zhani.
    - CVE-2026-14408: Uninitialized Use in Dawn. Reported by Chrovus.
    - CVE-2026-14381: Incorrect security UI in WebAppInstalls.
      Reported by Hafiizh.
    - CVE-2026-14383: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-13861: Use after free in Core. Reported by Google.
    - CVE-2026-13862: Insufficient policy enforcement in Web Authentication
      (Passkeys & Security Keys). Reported by Google.
    - CVE-2026-13863: Insufficient validation of untrusted input in
      CustomTabs. Reported by Google.
    - CVE-2026-13864: Insufficient policy enforcement in WebHID.
      Reported by Google.
    - CVE-2026-13865: Insufficient validation of untrusted input in
      Enterprise. Reported by Google.
    - CVE-2026-13866: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-13867: Inappropriate implementation in Geolocation.
      Reported by Google.
    - CVE-2026-13868: Inappropriate implementation in Network.
      Reported by Google.
    - CVE-2026-14384: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-13869: Use after free in Device. Reported by Google.
    - CVE-2026-13870: Use after free in WebView. Reported by Google.
    - CVE-2026-13871: Insufficient data validation in GuestView.
      Reported by Google.
    - CVE-2026-13872: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-13873: Out of bounds memory access in Layout. Reported by
      Google.
    - CVE-2026-13874: Inappropriate implementation in DataTransfer.
      Reported by Google.
    - CVE-2026-13875: Insufficient validation of untrusted input in GPU.
      Reported by Google.
    - CVE-2026-13876: Inappropriate implementation in Network.
      Reported by Google.
    - CVE-2026-13877: Insufficient validation of untrusted input in ANGLE.
      Reported by Google.
    - CVE-2026-13878: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-13879: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-13880: Use after free in USB. Reported by Google.
    - CVE-2026-13881: Insufficient data validation in WebAppInstalls.
      Reported by Google.
    - CVE-2026-13882: Inappropriate implementation in USB. Reported by Google
    - CVE-2026-13883: Type Confusion in ANGLE. Reported by Google.
    - CVE-2026-13884: Heap buffer overflow in Chromecast. Reported by Google.
    - CVE-2026-14387: Integer overflow in Skia. Reported by Google.
    - CVE-2026-13885: Use after free in Skia. Reported by Google.
    - CVE-2026-13886: Policy bypass in Isolated Web Apps. Reported by Google.
    - CVE-2026-14388: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-14389: Integer overflow in Skia. Reported by Google.
    - CVE-2026-13887: Insufficient policy enforcement in NFC.
      Reported by Google.
    - CVE-2026-13888: Use after free in Extensions. Reported by Google.
    - CVE-2026-13889: Insufficient validation of untrusted input in
      WebAuthentication. Reported by Google.
    - CVE-2026-13890: Out of bounds read in Chromecast. Reported by Google.
    - CVE-2026-13891: Insufficient validation of untrusted input in
      Extensions. Reported by Google.
    - CVE-2026-13892: Inappropriate implementation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13893: Insufficient validation of untrusted input in WebUI.
      Reported by Google.
    - CVE-2026-13894: Insufficient policy enforcement in Network.
      Reported by Google.
    - CVE-2026-13895: Inappropriate implementation in Autofill.
      Reported by Google.
    - CVE-2026-13896: Insufficient policy enforcement in Glic.
      Reported by Google.
    - CVE-2026-13897: Insufficient policy enforcement in Chromecast.
      Reported by Google.
    - CVE-2026-13898: Use after free in Cast Receiver. Reported by Google.
    - CVE-2026-13899: Use after free in HTML. Reported by Google.
    - CVE-2026-13900: Insufficient validation of untrusted input in
      Chromecast. Reported by Google.
    - CVE-2026-13901: Insufficient validation of untrusted input in Serial.
      Reported by Google.
    - CVE-2026-13902: Inappropriate implementation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13903: Insufficient policy enforcement in Bluetooth.
      Reported by Google.
    - CVE-2026-13904: Incorrect security UI in Safe Browsing.
      Reported by Google.
    - CVE-2026-13905: Incorrect security UI in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13906: Out of bounds read in Codecs. Reported by Google.
    - CVE-2026-13907: Inappropriate implementation in iOSWeb.
      Reported by Google.
    - CVE-2026-13908: Insufficient validation of untrusted input in Omnibox.
      Reported by Google.
    - CVE-2026-13909: Insufficient policy enforcement in DevTools.
      Reported by Google.
    - CVE-2026-13910: Insufficient policy enforcement in WebXR.
      Reported by Google.
    - CVE-2026-13911: Insufficient data validation in Spellcheck.
      Reported by Google.
    - CVE-2026-13912: Incorrect security UI in Safe Browsing.
      Reported by Google.
    - CVE-2026-13913: Insufficient policy enforcement in Autofill.
      Reported by Google.
    - CVE-2026-13914: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-13915: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-13916: Inappropriate implementation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13917: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-13918: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-13919: Insufficient data validation in Extensions.
      Reported by Google.
    - CVE-2026-14393: Use after free in V8. Reported by Google.
    - CVE-2026-13920: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-13921: Insufficient validation of untrusted input in
      DeviceBoundSessionCredentials. Reported by Google.
    - CVE-2026-13922: Side-channel information leakage in Paint.
      Reported by Google.
    - CVE-2026-13923: Uninitialized Use in GPU. Reported by Google.
    - CVE-2026-14397: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-13924: Insufficient validation of untrusted input in WebView.
      Reported by Google.
    - CVE-2026-13925: Inappropriate implementation in Downloads.
      Reported by Google.
    - CVE-2026-13926: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-13927: Insufficient validation of untrusted input in UI.
      Reported by Google.
    - CVE-2026-13928: Insufficient validation of untrusted input in
      Enterprise. Reported by Google.
    - CVE-2026-13929: Insufficient validation of untrusted input in DevTools.
      Reported by LegioSec.
    - CVE-2026-13930: Insufficient policy enforcement in Actor.
      Reported by Google.
    - CVE-2026-13931: Inappropriate implementation in Media.
      Reported by Google.
    - CVE-2026-13932: Inappropriate implementation in Sharing.
      Reported by Google.
    - CVE-2026-13933: Insufficient policy enforcement in Passwords.
      Reported by Google.
    - CVE-2026-13934: Insufficient validation of untrusted input in Dawn.
      Reported by Google.
    - CVE-2026-14399: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-13935: Side-channel information leakage in ComputePressure.
      Reported by Google.
    - CVE-2026-13936: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-13937: Insufficient policy enforcement in Passwords.
      Reported by Google.
    - CVE-2026-13938: Integer overflow in Fonts. Reported by Google.
    - CVE-2026-13939: Insufficient validation of untrusted input in WebShare.
      Reported by Google.
    - CVE-2026-13940: Uninitialized Use in Cast. Reported by Google.
    - CVE-2026-13941: Inappropriate implementation in SiteSettings.
      Reported by Google.
    - CVE-2026-13942: Insufficient validation of untrusted input in Video
      Capture. Reported by Google.
    - CVE-2026-13943: Uninitialized Use in CSS. Reported by Google.
    - CVE-2026-13944: Inappropriate implementation in DataTransfer.
      Reported by Google.
    - CVE-2026-13945: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-13946: Inappropriate implementation in ScriptInjections.
      Reported by Google.
    - CVE-2026-13947: Uninitialized Use in XR. Reported by Google.
    - CVE-2026-13948: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-13949: Insufficient policy enforcement in Payments.
      Reported by Google.
    - CVE-2026-14404: Inappropriate implementation in PDFium.
      Reported by Google.
    - CVE-2026-13950: Uninitialized Use in GPU. Reported by Google.
    - CVE-2026-13951: Policy bypass in USB. Reported by Google.
    - CVE-2026-13952: Inappropriate implementation in PerformanceAPIs.
      Reported by Google.
    - CVE-2026-14406: Out of bounds read in V8. Reported by Google.
    - CVE-2026-13953: Inappropriate implementation in SplitView.
      Reported by Google.
    - CVE-2026-13954: Insufficient policy enforcement in XML.
      Reported by Google.
    - CVE-2026-13955: Insufficient validation of untrusted input in
      CustomTabs. Reported by Google.
    - CVE-2026-13956: Incorrect security UI in PageInfo. Reported by Google.
    - CVE-2026-13957: Incorrect security UI in Extensions. Reported by Google
    - CVE-2026-13958: Uninitialized Use in Codecs. Reported by Google.
    - CVE-2026-14407: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-13959: Insufficient validation of untrusted input in Blink.
      Reported by Google.
    - CVE-2026-13960: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-13961: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-13962: Insufficient data validation in PDF. Reported by Google
    - CVE-2026-13963: Inappropriate implementation in DevTools.
      Reported by Google.
    - CVE-2026-13964: Insufficient policy enforcement in WebView.
      Reported by Google.
    - CVE-2026-13965: Use after free in Oilpan. Reported by Google.
    - CVE-2026-13966: Inappropriate implementation in History.
      Reported by Google.
    - CVE-2026-13967: Type Confusion in V8. Reported by Google.
    - CVE-2026-13968: Insufficient validation of untrusted input in DevTools.
      Reported by Google.
    - CVE-2026-13969: Uninitialized Use in UI. Reported by Google.
    - CVE-2026-13970: Uninitialized Use in Media. Reported by Google.
    - CVE-2026-13971: Uninitialized Use in Skia. Reported by Google.
    - CVE-2026-13972: Inappropriate implementation in Paint.
      Reported by Google.
    - CVE-2026-13973: Inappropriate implementation in UI. Reported by Google.
    - CVE-2026-13974: Integer overflow in Safe Browsing. Reported by Google.
    - CVE-2026-13975: Out of bounds read in ANGLE. Reported by Google.
    - CVE-2026-13976: Heap buffer overflow in Storage. Reported by Google.
    - CVE-2026-13977: Inappropriate implementation in HTMLParser.
      Reported by Google.
    - CVE-2026-13978: Insufficient policy enforcement in PageInfo.
      Reported by Google.
    - CVE-2026-14414: Insufficient validation of untrusted input in Skia.
      Reported by Google.
    - CVE-2026-13979: Inappropriate implementation in Paint. Reported by
      Google.
    - CVE-2026-13980: Incorrect security UI in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13981: Inappropriate implementation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13982: Incorrect security UI in Passwords. Reported by Google.
    - CVE-2026-13983: Incorrect security UI in Chrome for iOS.
      Reported by Google.
    - CVE-2026-13984: Incorrect security UI in TabStrip. Reported by Google.
    - CVE-2026-13985: Inappropriate implementation in MediaCapture.
      Reported by Google.
    - CVE-2026-13986: Inappropriate implementation in Media UI.
      Reported by Google.
    - CVE-2026-13987: Incorrect security UI in Mobile. Reported by Google.
    - CVE-2026-13988: Inappropriate implementation in Paint.
      Reported by Google.
    - CVE-2026-13989: Insufficient policy enforcement in PageInfo.
      Reported by Google.
    - CVE-2026-13990: Insufficient validation of untrusted input in
      DataTransfer. Reported by Google.
    - CVE-2026-13991: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-13992: Inappropriate implementation in UI. Reported by Google.
    - CVE-2026-13993: Incorrect security UI in WebAppInstalls.
      Reported by Google.
    - CVE-2026-13994: Inappropriate implementation in Credential Management.
      Reported by Google.
    - CVE-2026-13995: Insufficient validation of untrusted input in Autofill.
      Reported by Google.
    - CVE-2026-13996: Incorrect security UI in Permissions.
      Reported by Google.
    - CVE-2026-13997: Incorrect security UI in Extensions. Reported by Google
    - CVE-2026-13998: Incorrect security UI in File Input. Reported by Google
    - CVE-2026-13999: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-14000: Inappropriate implementation in XML. Reported by Google
    - CVE-2026-14001: Inappropriate implementation in Network.
      Reported by Google.
    - CVE-2026-14002: Inappropriate implementation in Geolocation.
      Reported by Google.
    - CVE-2026-14003: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-14004: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-14005: Use after free in Omnibox. Reported by Google.
    - CVE-2026-14006: Use after free in Navigation. Reported by Google.
    - CVE-2026-14007: Insufficient policy enforcement in PermissionsPolicy.
      Reported by Google.
    - CVE-2026-14008: Uninitialized Use in WebXR. Reported by Google.
    - CVE-2026-14009: Insufficient data validation in Passwords.
      Reported by Google.
    - CVE-2026-14010: Uninitialized Use in Codecs. Reported by Google.
    - CVE-2026-14011: Out of bounds read in SurfaceCapture.
      Reported by Google.
    - CVE-2026-14421: Uninitialized Use in Dawn. Reported by Google.
    - CVE-2026-14012: Side-channel information leakage in CSS.
      Reported by Google.
    - CVE-2026-14013: Inappropriate implementation in SVG. Reported by Google
    - CVE-2026-14014: Inappropriate implementation in Paint.
      Reported by Google.
    - CVE-2026-14015: Inappropriate implementation in WebRTC.
      Reported by Google.
    - CVE-2026-14016: Insufficient policy enforcement in SVG.
      Reported by Google.
    - CVE-2026-14017: Inappropriate implementation in Navigation.
      Reported by Google.
    - CVE-2026-14018: Use after free in Updater. Reported by Google.
    - CVE-2026-14019: Inappropriate implementation in Passwords.
      Reported by Google.
    - CVE-2026-14020: Insufficient validation of untrusted input in WebXR.
      Reported by Google.
    - CVE-2026-14021: Insufficient validation of untrusted input in
      StorageAccessAPI. Reported by Google.
    - CVE-2026-14022: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-14023: Insufficient validation of untrusted input in
      SanitizerAPI. Reported by Google.
    - CVE-2026-14024: Use after free in Ozone. Reported by Google.
    - CVE-2026-14432: Use after free in V8. Reported by Google.
    - CVE-2026-14025: Use after free in Views. Reported by asjidkalam.
    - CVE-2026-14026: Incorrect security UI in SplitView.
      Reported by adisahilna35@gmail.com.
    - CVE-2026-14027: Use after free in SignIn.
      Reported by Sven Dysthe (@svn-dys).
    - CVE-2026-14028: Incorrect security UI in Chrome for iOS.
      Reported by Ameen Basha M K.
    - CVE-2026-14030: Incorrect security UI in SplitView.
      Reported by Khalil Zhani.
    - CVE-2026-14031: Incorrect security UI in File Input. Reported by Google
    - CVE-2026-14032: Use after free in Bluetooth. Reported by Google.
    - CVE-2026-14033: Insufficient policy enforcement in Media.
      Reported by Google.
    - CVE-2026-14034: Inappropriate implementation in WebXR.
      Reported by Google.
    - CVE-2026-14035: Insufficient policy enforcement in Bluetooth.
      Reported by Google.
    - CVE-2026-14036: Insufficient policy enforcement in Bluetooth.
      Reported by Google.
    - CVE-2026-14037: Insufficient policy enforcement in GPU.
      Reported by Google.
    - CVE-2026-14038: Insufficient validation of untrusted input in New
      Tab Page. Reported by Google.
    - CVE-2026-14039: Insufficient policy enforcement in GetUserMedia.
      Reported by Google.
    - CVE-2026-14040: Use after free in BrowserTag. Reported by Google.
    - CVE-2026-14041: Insufficient policy enforcement in Serial.
      Reported by Google.
    - CVE-2026-14042: Inappropriate implementation in Isolated Web Apps.
      Reported by Google.
    - CVE-2026-14043: Use after free in GetUserMedia. Reported by Google.
    - CVE-2026-14044: Use after free in ANGLE. Reported by Google.
    - CVE-2026-14045: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-14046: Inappropriate implementation in CustomTabs.
      Reported by Google.
    - CVE-2026-14047: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-14048: Use after free in Chromecast. Reported by Google.
    - CVE-2026-14049: Inappropriate implementation in GPU. Reported by Google
    - CVE-2026-14050: Insufficient policy enforcement in Passwords.
      Reported by Google.
    - CVE-2026-14051: Uninitialized Use in GamepadAPI. Reported by Google.
    - CVE-2026-14052: Insufficient policy enforcement in FileSystem.
      Reported by Google.
    - CVE-2026-14053: Insufficient policy enforcement in Extensions.
      Reported by Google.
    - CVE-2026-14054: Insufficient policy enforcement in Network.
      Reported by Google.
    - CVE-2026-14055: Insufficient validation of untrusted input in Device
      Trust. Reported by Google.
    - CVE-2026-14056: Insufficient validation of untrusted input in Media.
      Reported by Google.
    - CVE-2026-14057: Insufficient policy enforcement in FedCM.
      Reported by Google.
    - CVE-2026-14058: Policy bypass in Parser. Reported by Google.
    - CVE-2026-14059: Insufficient policy enforcement in
      Related-Website-Sets. Reported by Google.
    - CVE-2026-14060: Insufficient validation of untrusted input in
      Chromoting. Reported by Google.
    - CVE-2026-14061: Inappropriate implementation in Dawn.
      Reported by Google.
    - CVE-2026-14062: Inappropriate implementation in Views.
      Reported by Google.
    - CVE-2026-14063: Out of bounds memory access in Chromecast.
      Reported by Google.
    - CVE-2026-14064: Use after free in PageInfo. Reported by Google.
    - CVE-2026-14065: Insufficient validation of untrusted input in
      PageInfo. Reported by Google.
    - CVE-2026-14066: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-14067: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-14068: Inappropriate implementation in Omnibox.
      Reported by Google.
    - CVE-2026-14069: Integer overflow in WebNN. Reported by Google.
    - CVE-2026-14070: Uninitialized Use in WebNN. Reported by Google.
    - CVE-2026-14071: Side-channel information leakage in WebAudio.
      Reported by Google.
    - CVE-2026-14072: Incorrect security UI in SplitView.
      Reported by FARISSAL B.
    - CVE-2026-14073: Insufficient policy enforcement in WebXR.
      Reported by Google.
    - CVE-2026-14394: Use after free in V8. Reported by Google.
    - CVE-2026-14395: Out of bounds write in V8. Reported by Google.
    - CVE-2026-14074: Side-channel information leakage in WebAuthentication.
      Reported by Google.
    - CVE-2026-14075: Policy bypass in Chrome for iOS. Reported by Google.
    - CVE-2026-14076: Policy bypass in Network. Reported by Google.
    - CVE-2026-14077: Incorrect security UI in Select. Reported by pwn.ai.
    - CVE-2026-14078: Policy bypass in WebRTC. Reported by Google.
    - CVE-2026-14079: Policy bypass in Network. Reported by Google.
    - CVE-2026-14080: Insufficient validation of untrusted input in
      TabSwitcher. Reported by Google.
    - CVE-2026-14081: Insufficient policy enforcement in DevTools.
      Reported by Google.
    - CVE-2026-14082: Race in Storage. Reported by Google.
    - CVE-2026-14083: Insufficient validation of untrusted input in HTML.
      Reported by Google.
    - CVE-2026-14084: Insufficient validation of untrusted input in
      Chromoting. Reported by Google.
    - CVE-2026-14085: Side-channel information leakage in CSS.
      Reported by Google.
    - CVE-2026-14086: Insufficient policy enforcement in HID.
      Reported by Google.
    - CVE-2026-14087: Insufficient validation of untrusted input in WebNN.
      Reported by Google.
    - CVE-2026-14088: Uninitialized Use in Canvas. Reported by Google.
    - CVE-2026-14089: Insufficient validation of untrusted input in
      PopupBlocker. Reported by Google.
    - CVE-2026-14090: Out of bounds read in CameraCapture. Reported by Google
    - CVE-2026-14091: Use after free in DevTools. Reported by Google.
    - CVE-2026-14092: Insufficient policy enforcement in Privacy.
      Reported by Google.
    - CVE-2026-14093: Use after free in Cast. Reported by Google.
    - CVE-2026-14094: Use after free in Installer. Reported by Google.
    - CVE-2026-14095: Insufficient validation of untrusted input in Browser.
      Reported by Google.
    - CVE-2026-14403: Use after free in V8. Reported by Google.
    - CVE-2026-14096: Object lifecycle issue in Input. Reported by Google.
    - CVE-2026-14097: Inappropriate implementation in WebAppInstalls.
      Reported by Google.
    - CVE-2026-14098: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-14405: Uninitialized Use in V8. Reported by Google.
    - CVE-2026-14099: Use after free in Chrome for iOS. Reported by Google.
    - CVE-2026-14100: Insufficient data validation in NetworkCache.
      Reported by Google.
    - CVE-2026-14101: Insufficient policy enforcement in Sandbox.
      Reported by Google.
    - CVE-2026-14102: Use after free in Passwords. Reported by Google.
    - CVE-2026-14103: Use after free in SSL. Reported by Google.
    - CVE-2026-14104: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-14105: Insufficient policy enforcement in Speech.
      Reported by Google.
    - CVE-2026-14106: Insufficient validation of untrusted input in Text.
      Reported by Google.
    - CVE-2026-14107: Use after free in Scheduling. Reported by Google.
    - CVE-2026-14108: Use after free in PDFium. Reported by Google.
    - CVE-2026-14109: Insufficient policy enforcement in Mojo.
      Reported by Google.
    - CVE-2026-14110: Inappropriate implementation in DarkMode.
      Reported by Google.
    - CVE-2026-14111: Use after free in WebProtect. Reported by Google.
    - CVE-2026-14112: Inappropriate implementation in Enterprise.
      Reported by Google.
    - CVE-2026-14113: Use after free in Updater. Reported by Google.
    - CVE-2026-14114: Inappropriate implementation in WebAppInstalls.
      Reported by Google.
    - CVE-2026-14115: Insufficient validation of untrusted input in Cast.
      Reported by Google.
    - CVE-2026-14116: Insufficient validation of untrusted input in
      DevTools. Reported by Google.
    - CVE-2026-14117: Insufficient validation of untrusted input in
      DevTools. Reported by Google.
    - CVE-2026-14118: Insufficient data validation in DevTools.
      Reported by Google.
    - CVE-2026-14119: Type Confusion in Bluetooth. Reported by Google.
    - CVE-2026-14120: Inappropriate implementation in DevTools.
      Reported by Google.
    - CVE-2026-14121: Use after free in Chromoting. Reported by Google.
    - CVE-2026-14409: Inappropriate implementation in V8.
      Reported by Yuntao You (@GraVity0) of Bytedance Wuheng Lab.
    - CVE-2026-14122: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-14410: Inappropriate implementation in Skia.
      Reported by Google.
    - CVE-2026-14123: Incorrect security UI in Chrome for iOS.
      Reported by Google.
    - CVE-2026-14124: Inappropriate implementation in CredentialProvider.
      Reported by Google.
    - CVE-2026-14125: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-14126: Incorrect security UI in UI. Reported by Google.
    - CVE-2026-14127: Inappropriate implementation in Printing.
      Reported by Google.
    - CVE-2026-14128: Insufficient data validation in Chrome for iOS.
      Reported by Google.
    - CVE-2026-14129: Incorrect security UI in PreviewTab. Reported by Google
    - CVE-2026-14130: Incorrect security UI in Omnibox. Reported by Google.
    - CVE-2026-14131: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-14132: Inappropriate implementation in WebXR.
      Reported by Google.
    - CVE-2026-14133: Race in History Embeddings. Reported by Google.
    - CVE-2026-14134: Inappropriate implementation in Autofill.
      Reported by Google.
    - CVE-2026-14135: Insufficient validation of untrusted input in Network.
      Reported by Google.
    - CVE-2026-14136: Incorrect security UI in Chrome for iOS.
      Reported by Google.
    - CVE-2026-14137: Insufficient validation of untrusted input in Chrome
      for iOS. Reported by Google.
    - CVE-2026-14138: Inappropriate implementation in WebAppInstalls.
      Reported by Google.
    - CVE-2026-14139: Inappropriate implementation in TabStrip.
      Reported by Google.
    - CVE-2026-14140: Insufficient validation of untrusted input in Input.
      Reported by Google.
    - CVE-2026-14141: Incorrect security UI in Document Picture-in-Picture.
      Reported by Google.
    - CVE-2026-14142: Inappropriate implementation in Extensions.
      Reported by Google.
    - CVE-2026-14143: Incorrect security UI in Passwords. Reported by Google.
    - CVE-2026-14144: Incorrect security UI in Views. Reported by Google.
    - CVE-2026-14145: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-14146: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-14147: Inappropriate implementation in CSS. Reported by Google
    - CVE-2026-14415: Inappropriate implementation in V8. Reported by Google.
    - CVE-2026-14148: Type Confusion in CSS. Reported by Google.
    - CVE-2026-14149: Use after free in Audio. Reported by Google.
    - CVE-2026-14416: Out of bounds read in Dawn. Reported by Google.
    - CVE-2026-14150: Insufficient validation of untrusted input in Speech.
      Reported by Google.
    - CVE-2026-14151: Inappropriate implementation in AI. Reported by Google.
    - CVE-2026-14152: Out of bounds write in ANGLE. Reported by Google.
    - CVE-2026-14153: Inappropriate implementation in Glic.
      Reported by Google.
    - CVE-2026-14154: Inappropriate implementation in DevTools.
      Reported by Google.
    - CVE-2026-14155: Insufficient policy enforcement in StorageAccessAPI.
      Reported by Google.
    - CVE-2026-14156: Policy bypass in StorageAccessAPI. Reported by Google.
    - CVE-2026-13281: Integer overflow in Mojo. Reported by Google.
    - CVE-2026-13282: Use after free in Payments. Reported by Google.
    - CVE-2026-13283: Use after free in AdFilter. Reported by Google.
  * d/copyright:
    - delete third_party/webpagereplay/.
    - delete tsgo (typescript compiler in Go) binary.
  * d/patches:
    - upstream/0001-Fix-build-for-CPU-yield-on-LoongArch.patch: drop, merged
      upstream.
    - disable/android.patch: drop, merged upstream.
    - debianization/clang-version.patch: refresh.
    - fixes/libcpp-headers.patch: rework parts of the patch due to
      upstream changes.
    - disable/catapult.patch: refresh.
    - disable/tests.patch: refresh.
    - llvm-19/clang19.patch: refresh.
    - trixie/gn-expand-dir-allowlist.patch: refresh.
    - ungoogled/disable-ai.patch: sync from u-c.
    - ungoogled/remove-navigation-source-param.patch: sync from u-c.
    - i386/support-i386.patch: refresh.
    - upstream/sysroot.patch: add a new build fix pulled from upstream.
    - upstream/ar-path1.patch, upstream/ar-path2.patch: add two more
      vendoring-related build fixes from upstream.
    - trixie/gn-additional-outputs.patch: add patch to partially revert usage
      of a newer generate-ninja feature.
    - llvm-19/i18n-builder-enum.patch: add a workaround for clang-19 being
      confused between a class declaration (with default template parameter)
      and definition.
    - llvm-19/00*-revert-v8-libm.patch: add 9 patches backing out usage of
      internal libc++/libm symbols; this requires a newer llvm than we have.
    - llvm-19/value-or.patch: work around more places where value_or() can't
      figure out the type of a passed init value.
    - trixie/node20-compat.patch: break out part of Daniel's
      node18-compat.patch (below) into one for trixie that also fixes nodejs
      20 issues [trixie, bookworm].
    - rust-1.85/std-from-utf8.patch: add workaround for str::from_utf8 added
      in 1.87 [trixie, bookworm].
    - trixie/bindgen-boringssl.patch: add workaround for older bindgen
      [trixie, bookworm].

  [ Daniel Richard G. ]
  * d/patches:
    - bookworm/gn-absl.patch: Refresh [bookworm].
    - bookworm/gn-funcs.patch: Zap new usage of filter_labels_include()
      [bookworm].
    - bookworm/node18-compat.patch: Fix more cases of nodejs v18 breakage
      [bookworm].
    - trixie/gn-module-name.patch: add more spots where the workaround is
      needed [trixie, bookworm].

  [ Jianfeng Liu ]
  * d/patches:
    - upstream/libyuv-loongarch-fix-row_lsx.cc-and-row_lasx.cc.patch: Fix
      build for libyuv loongarch64.
    - loongarch64/0015-ffmpeg-support-for-loongarch.patch: Refresh.

  [ Timothy Pearson ]
  * d/patches/ppc64le:
    - third_party/0002-regenerate-xnn-buildgn.patch: refresh for upstream
      changes
    - fixes/fix-rust-linking.patch: refresh for upstream changes
    - fixes/fix-breakpad-compile.patch: refresh for upstream changes
    - third_party/dawn-fix-ppc64le-detection.patch: refresh for upstream
      changes
    - 0001-Add-pregenerated-config-for-libaom-on-ppc64.patch: refresh for
      upstream changes
```