### PR TITLE
Docker: Update Go to 1.26.5, Debian and Chromium to 150.0.7871.114

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build \
   -ldflags '-s -w -extldflags "-static"' \
   .
 
-FROM debian:trixie-20260623@sha256:d07d1b51c39f51188e60be9b64e6bf769fa94e187f092bc32b91305cfa34ba5a AS output_image
+FROM debian:trixie-20260713@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4 AS output_image
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-07-09' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-07-14' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=150.0.7871.100
+ARG CHROMIUM_VERSION=150.0.7871.114
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #        -> Why static linking? We want to ensure we can switch base-image with little to no effort.
 #   2. It builds a running environment. This is the environment that exists for the Go binary, and should have all necessary pieces to run the application.
 
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS app
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS app
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-image-renderer
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Updates Go to 1.26.5 to fix https://github.com/advisories/GHSA-xcgv-8mv7-v8c7, Debian to trixie from July, and Chromium to fix the following CVEs
```
chromium (150.0.7871.114-1~deb13u1) trixie-security; urgency=high

  [ Andres Salomon ]
  * New upstream security release.
    - CVE-2026-15112: Use after free in Ozone. Reported by Google.
    - CVE-2026-15129: Use after free in Views. Reported by Google.
    - CVE-2026-15132: Uninitialized Use in V8.
      Reported by Pierre Langlois from Arm.
    - CVE-2026-15133: Use after free in InterestGroups. Reported by Jihyeon
      Jeong (Compsec Lab, Seoul National University / Research Intern).
    - CVE-2026-15108: Integer overflow in Extensions API. Reported by Google.
    - CVE-2026-15109: Uninitialized Use in ANGLE. Reported by Google.
    - CVE-2026-15110: Use after free in Extensions. Reported by Google.
    - CVE-2026-15111: Use after free in Views. Reported by Google.
    - CVE-2026-15113: Use after free in Autofill. Reported by Google.
    - CVE-2026-15114: Out of bounds read and write in Codecs.
      Reported by Google.
    - CVE-2026-15115: Insufficient validation of untrusted input in
      WebAppInstalls. Reported by Google.
    - CVE-2026-15116: Use after free in Actor. Reported by Google.
    - CVE-2026-15117: Use after free in Payments. Reported by Google.
    - CVE-2026-15118: Use after free in Input. Reported by Google.
    - CVE-2026-15119: Inappropriate implementation in GetUserMedia.
      Reported by Google.
    - CVE-2026-15120: Use after free in Core. Reported by Google.
    - CVE-2026-15121: Use after free in WebRTC. Reported by Google.
    - CVE-2026-15122: Insufficient validation of untrusted input in Codecs.
      Reported by Google.
    - CVE-2026-15123: Insufficient data validation in DOM. Reported by Google
    - CVE-2026-15124: Insufficient policy enforcement in Passwords.
      Reported by Google.
    - CVE-2026-15125: Inappropriate implementation in Forms.
      Reported by Google.
    - CVE-2026-15126: Use after free in Forms. Reported by Google.
    - CVE-2026-15127: Inappropriate implementation in WebGL.
      Reported by Google.
    - CVE-2026-15128: Inappropriate implementation in Forms.
      Reported by Google.
    - CVE-2026-15130: Insufficient policy enforcement in Navigation.
      Reported by Google.
    - CVE-2026-15107: Use after free in IndexedDB.
      Reported by zh1x1an1221 of Ant Group Tianqiong Security Lab.
    - CVE-2026-15131: Insufficient data validation in Navigation.
      Reported by Google.
```