### PR TITLE
API: Redact renderKey in the panic recovery log

### DIFF
--- a/pkg/api/middleware/recovery.go
+++ b/pkg/api/middleware/recovery.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/codes"
@@ -26,7 +27,7 @@ func Recovery(h http.Handler) http.Handler {
 			if err := recover(); err != nil {
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				MetricRecoveredRequests.Inc()
-				slog.ErrorContext(ctx, "Request panicked", "panic", err, "url", r.URL, "method", r.Method)
+				slog.ErrorContext(ctx, "Request panicked", "panic", err, "url", redactedURL(r.URL), "method", r.Method)
 				span.SetStatus(codes.Error, "panic in HTTP handler")
 			}
 		}()
@@ -34,4 +35,17 @@ func Recovery(h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 		span.SetStatus(codes.Ok, "no panic")
 	})
+}
+
+// redactedURL returns the URL as a string with the renderKey query parameter
+// value masked, so panic logs never contain the Grafana auth token.
+func redactedURL(u *url.URL) string {
+	q := u.Query()
+	if q.Has("renderKey") {
+		q.Set("renderKey", "-redacted-")
+		redacted := *u
+		redacted.RawQuery = q.Encode()
+		return redacted.String()
+	}
+	return u.String()
 }

--- a/pkg/api/middleware/recovery_internal_test.go
+++ b/pkg/api/middleware/recovery_internal_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactedURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "renderKey is masked",
+			in:   "/render?renderKey=supersecret&url=http%3A%2F%2Fgrafana%2Fd%2Fabc&width=1000",
+			want: "/render?renderKey=-redacted-&url=http%3A%2F%2Fgrafana%2Fd%2Fabc&width=1000",
+		},
+		{
+			name: "no renderKey leaves URL untouched",
+			in:   "/render?url=http%3A%2F%2Fgrafana%2Fd%2Fabc&width=1000",
+			want: "/render?url=http%3A%2F%2Fgrafana%2Fd%2Fabc&width=1000",
+		},
+		{
+			name: "no query at all",
+			in:   "/render",
+			want: "/render",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.in)
+			require.NoError(t, err, "parsing test URL")
+			require.Equal(t, tc.want, redactedURL(u), "redacted URL")
+		})
+	}
+}


### PR DESCRIPTION
The `Recovery` middleware logs the full request URL when a handler panics:

```go
slog.ErrorContext(ctx, "Request panicked", "panic", err, "url", r.URL, "method", r.Method)
```

For `/render` requests that URL includes the `renderKey` query parameter — a short-lived Grafana auth token — so a panic writes a live credential into the service logs.

This PR masks the `renderKey` value in that log line while keeping the rest of the URL (inner dashboard `url`, `width`, `height`, `timeout`, …) intact for debugging. Requests without a `renderKey` are logged unchanged.

Added a table-driven unit test for the redaction helper; `go test ./pkg/api/middleware/` passes, `gofmt`/`go vet` clean.