### PR TITLE
Config: Trim extra comma from browser.flag when using a config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,6 +20,79 @@ func noopSpan() trace.Span {
 	return span
 }
 
+func TestBrowserFlagsFromConfigFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		content  string
+	}{
+		{
+			filename: "config.yaml",
+			content: `
+browser:
+  flag:
+    - '--dummy-test-for-trailing-comma,'
+    - '--user-data-dir=/Users/test'
+    - '--window-size=1920,1080'
+    - '--ignore-certificate-errors'
+`,
+		},
+		{
+			filename: "config.json",
+			content: `{
+  "browser": {
+    "flag": [
+      "--dummy-test-for-trailing-comma,",
+      "--user-data-dir=/Users/test",
+      "--window-size=1920,1080",
+      "--ignore-certificate-errors"
+    ]
+  }
+}`,
+		},
+	}
+
+	want := []string{
+		"--dummy-test-for-trailing-comma,",
+		"--user-data-dir=/Users/test",
+		"--window-size=1920,1080",
+		"--ignore-certificate-errors",
+	}
+
+	parseBrowserConfig := func(t *testing.T) BrowserConfig {
+		t.Helper()
+
+		var browserConfig BrowserConfig
+		cmd := &cli.Command{
+			Flags: BrowserFlags(),
+			Action: func(_ context.Context, c *cli.Command) error {
+				var err error
+				browserConfig, err = BrowserConfigFromCommand(c)
+				return err
+			},
+		}
+
+		require.NoError(t, cmd.Run(t.Context(), []string{""}))
+		return browserConfig
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			require.NoError(t, os.WriteFile(tt.filename, []byte(tt.content), 0o600))
+
+			browserConfig := parseBrowserConfig(t)
+			require.Equal(t, want, browserConfig.Flags)
+		})
+	}
+
+	t.Run("using env vars", func(t *testing.T) {
+		t.Setenv("BROWSER_FLAG", "--dummy-test-for-trailing-comma, --user-data-dir=/Users/test --window-size=1920,1080 --ignore-certificate-errors")
+
+		browserConfig := parseBrowserConfig(t)
+		require.Equal(t, want, browserConfig.Flags)
+	})
+}
+
 func TestRenderRequestConfig(t *testing.T) {
 	defaultConfig := RequestConfig{
 		TimeBetweenScrolls:              50 * time.Millisecond,

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -124,7 +124,14 @@ func customParseBrowserFlags(flags string) []string {
 				}
 			}
 
-			collected = append(collected, strings.TrimSpace(flags[i:startOfNextFlag]))
+			// cli-altsrc joins configuration-file lists with commas.
+			// Remove only the comma directly adjoining the next flag, preserving commas in values.
+			endOfCurrentFlag := startOfNextFlag
+			if endOfCurrentFlag > i && flags[endOfCurrentFlag-1] == ',' {
+				endOfCurrentFlag--
+			}
+
+			collected = append(collected, strings.TrimSpace(flags[i:endOfCurrentFlag]))
 		}
 	}
 


### PR DESCRIPTION
When launching the renderer binary with a side-by-side config file (config.yaml), the declared browser flags are passed to the browser adding trailing commas.

This is a caveat of the custom parsing we need to do to accommodate the Chromium flags format and how "cli-altsrc" package handles it, by appending the `,` to the each item in the list.

So here we trim that extra comma at the end.

Added regression tests for both yaml and json configs as well as the env var parsing.

Closes https://github.com/grafana/grafana-image-renderer/issues/1023