### PR TITLE
Metrics: add readiness mode label for binding vs legacy comparison

### DIFF
--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-image-renderer/pkg/service"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -15,6 +16,7 @@ var (
 		Name: "http_requests_in_flight",
 		Help: "How many expensive requests are in flight?",
 	})
+	// TODO: Remove the mode label once a default readiness mode has been decided.
 	MetricRequestDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "http_request_duration",
 		Help: "How long does a request take?",
@@ -28,7 +30,8 @@ var (
 			125, 305, 605, 905, 1205,
 			1800, 3600,
 		},
-	}, []string{"method", "path", "status_code", "encoding"})
+	}, []string{"method", "path", "status_code", "encoding", "mode"})
+	// TODO: Remove the mode label once a default readiness mode has been decided.
 	MetricResponseSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "http_response_size",
 		Help: "How large is the rendered response (e.g. PNG/PDF/CSV) returned to the client?",
@@ -38,7 +41,7 @@ var (
 		//   2.0KB   3.1KB    4.8KB    7.4KB  11.5KB 17.9KB  27.7KB  42.8KB  66.4KB  102.8KB
 		// 159.3KB 246.8KB  382.4KB  592.4KB 917.8KB 1.39MB  2.15MB  3.33MB  5.16MB  8.00MB
 		Buckets: prometheus.ExponentialBucketsRange(2*1024, 8*1024*1024, 20),
-	}, []string{"method", "path", "status_code", "encoding"})
+	}, []string{"method", "path", "status_code", "encoding", "mode"})
 )
 
 // RequestMetrics adds some Prometheus metrics to the HTTP handler, to ensure we know what's going on with it.
@@ -47,6 +50,7 @@ func RequestMetrics(h http.Handler) http.Handler {
 		tracer := tracer(r.Context())
 		ctx, span := tracer.Start(r.Context(), "RequestMetrics")
 		defer span.End()
+		ctx, readinessMode := service.ContextWithReadinessModeTracker(ctx)
 		r = r.WithContext(ctx)
 
 		encoding := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("encoding")))
@@ -58,8 +62,9 @@ func RequestMetrics(h http.Handler) http.Handler {
 		recorder := &statusRecordingResponseWriter{rw: w}
 		h.ServeHTTP(recorder, r)
 		statusCode := strconv.Itoa(recorder.status)
-		MetricRequestDurations.WithLabelValues(r.Method, r.Pattern, statusCode, encoding).Observe(time.Since(now).Seconds())
-		MetricResponseSize.WithLabelValues(r.Method, r.Pattern, statusCode, encoding).Observe(float64(recorder.bytesWritten))
+		mode := readinessMode.Get()
+		MetricRequestDurations.WithLabelValues(r.Method, r.Pattern, statusCode, encoding, mode).Observe(time.Since(now).Seconds())
+		MetricResponseSize.WithLabelValues(r.Method, r.Pattern, statusCode, encoding, mode).Observe(float64(recorder.bytesWritten))
 	})
 }
 

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -24,12 +24,13 @@ import (
 
 var (
 	// This also implicitly gives us a count for each result type, so we can calculate success rate.
+	// TODO: Remove the mode label once a default readiness mode has been decided.
 	MetricRenderDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:        "http_render_browser_request_duration",
 		Help:        "How long does a single render take, limited to the browser?",
 		ConstLabels: prometheus.Labels{"unit": "seconds"},
 		Buckets:     []float64{0.5, 1, 3, 4, 5, 7, 9, 10, 11, 15, 19, 20, 21, 24, 27, 29, 30, 31, 35, 55, 95, 125, 305, 605},
-	}, []string{"result", "encoding"})
+	}, []string{"result", "encoding", "mode"})
 
 	regexpOnlyNumbers = regexp.MustCompile(`^[0-9]+$`)
 )
@@ -232,8 +233,9 @@ func HandleGetRender(browser *service.BrowserService, apiConfig config.APIConfig
 
 		start := time.Now()
 		body, contentType, err := browser.Render(ctx, rawTargetURL, printer, options...)
+		mode := service.ReadinessModeFromContext(ctx)
 		if err != nil {
-			MetricRenderDuration.WithLabelValues("error", encoding).Observe(time.Since(start).Seconds())
+			MetricRenderDuration.WithLabelValues("error", encoding, mode).Observe(time.Since(start).Seconds())
 			span.SetStatus(codes.Error, "rendering failed")
 			span.RecordError(err)
 			if errors.Is(err, context.DeadlineExceeded) ||
@@ -249,7 +251,7 @@ func HandleGetRender(browser *service.BrowserService, apiConfig config.APIConfig
 			http.Error(w, "Failed to render", http.StatusInternalServerError)
 			return
 		}
-		MetricRenderDuration.WithLabelValues("success", encoding).Observe(time.Since(start).Seconds())
+		MetricRenderDuration.WithLabelValues("success", encoding, mode).Observe(time.Since(start).Seconds())
 		span.SetStatus(codes.Ok, "rendered successfully")
 
 		w.Header().Set("Content-Type", contentType)

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -77,6 +77,7 @@ var (
 		},
 		Buckets: []float64{1, 1024, 4 * 1024, 16 * 1024, 1024 * 1024, 4 * 1024 * 1024, 16 * 1024 * 1024, 64 * 1024 * 1024, 256 * 1024 * 1024},
 	}, []string{"mime_type"})
+	// TODO: Remove this metric (and mode labels on HTTP/render metrics) once a default readiness mode has been decided.
 	MetricBrowserReadinessMode = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "browser_readiness_mode_total",
 		Help: "Number of render requests by readiness detection mode: binding (chromedp binding) or legacy (polling).",
@@ -1096,7 +1097,9 @@ func waitForReady(browserCtx context.Context, cfg config.BrowserConfig, url stri
 		}
 
 		if supportsBinding && !requestConfig.ForcePollingMode {
-			MetricBrowserReadinessMode.WithLabelValues("binding").Inc()
+			// TODO: Remove mode labeling once a default readiness mode has been decided.
+			MetricBrowserReadinessMode.WithLabelValues(ReadinessModeBinding).Inc()
+			SetReadinessMode(ctx, ReadinessModeBinding)
 			span.AddEvent("using binding-based readiness")
 			select {
 			case <-ctx.Done():
@@ -1113,7 +1116,9 @@ func waitForReady(browserCtx context.Context, cfg config.BrowserConfig, url stri
 			}
 		}
 
-		MetricBrowserReadinessMode.WithLabelValues("legacy").Inc()
+		// TODO: Remove mode labeling once a default readiness mode has been decided.
+		MetricBrowserReadinessMode.WithLabelValues(ReadinessModeLegacy).Inc()
+		SetReadinessMode(ctx, ReadinessModeLegacy)
 		span.AddEvent("using legacy polling readiness")
 
 		hasSeenAnyQuery := false

--- a/pkg/service/readiness_mode.go
+++ b/pkg/service/readiness_mode.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+const (
+	ReadinessModeBinding = "binding"
+	ReadinessModeLegacy  = "legacy"
+	ReadinessModeUnknown = "unknown"
+)
+
+type readinessModeContextKey struct{}
+
+// ReadinessModeTracker records which readiness detection mode was used for a
+// render request so HTTP/render metrics can label observations by mode.
+//
+// TODO: Remove the mode label from metrics (and this tracker) once a default
+// readiness mode has been decided and the temporary dual-mode rollout ends.
+type ReadinessModeTracker struct {
+	mode atomic.Value // string
+}
+
+// ContextWithReadinessModeTracker attaches a readiness mode tracker to ctx.
+// Callers should mutate the returned tracker (or use SetReadinessMode) during
+// the request, then read the final value when recording metrics.
+func ContextWithReadinessModeTracker(ctx context.Context) (context.Context, *ReadinessModeTracker) {
+	t := &ReadinessModeTracker{}
+	t.mode.Store(ReadinessModeUnknown)
+	return context.WithValue(ctx, readinessModeContextKey{}, t), t
+}
+
+// SetReadinessMode records the readiness mode on the tracker in ctx, if any.
+func SetReadinessMode(ctx context.Context, mode string) {
+	if t, ok := ctx.Value(readinessModeContextKey{}).(*ReadinessModeTracker); ok && t != nil {
+		t.Set(mode)
+	}
+}
+
+// ReadinessModeFromContext returns the readiness mode recorded on ctx, or
+// ReadinessModeUnknown if none was set.
+func ReadinessModeFromContext(ctx context.Context) string {
+	if t, ok := ctx.Value(readinessModeContextKey{}).(*ReadinessModeTracker); ok && t != nil {
+		return t.Get()
+	}
+	return ReadinessModeUnknown
+}
+
+func (t *ReadinessModeTracker) Set(mode string) {
+	if t == nil {
+		return
+	}
+	t.mode.Store(mode)
+}
+
+func (t *ReadinessModeTracker) Get() string {
+	if t == nil {
+		return ReadinessModeUnknown
+	}
+	v, _ := t.mode.Load().(string)
+	if v == "" {
+		return ReadinessModeUnknown
+	}
+	return v
+}

--- a/pkg/service/readiness_mode_test.go
+++ b/pkg/service/readiness_mode_test.go
@@ -1,0 +1,39 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-image-renderer/pkg/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadinessModeTracker_DefaultsToUnknown(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, service.ReadinessModeUnknown, service.ReadinessModeFromContext(t.Context()))
+
+	ctx, tracker := service.ContextWithReadinessModeTracker(t.Context())
+	require.Equal(t, service.ReadinessModeUnknown, tracker.Get())
+	require.Equal(t, service.ReadinessModeUnknown, service.ReadinessModeFromContext(ctx))
+}
+
+func TestReadinessModeTracker_SetAndGet(t *testing.T) {
+	t.Parallel()
+
+	ctx, tracker := service.ContextWithReadinessModeTracker(t.Context())
+	service.SetReadinessMode(ctx, service.ReadinessModeBinding)
+
+	require.Equal(t, service.ReadinessModeBinding, tracker.Get())
+	require.Equal(t, service.ReadinessModeBinding, service.ReadinessModeFromContext(ctx))
+
+	service.SetReadinessMode(ctx, service.ReadinessModeLegacy)
+	require.Equal(t, service.ReadinessModeLegacy, service.ReadinessModeFromContext(ctx))
+}
+
+func TestSetReadinessMode_NoTrackerIsNoop(t *testing.T) {
+	t.Parallel()
+
+	service.SetReadinessMode(context.Background(), service.ReadinessModeBinding)
+	require.Equal(t, service.ReadinessModeUnknown, service.ReadinessModeFromContext(context.Background()))
+}


### PR DESCRIPTION
## Summary
- Add a temporary `mode` label (`binding` / `legacy` / `unknown`) to `http_render_browser_request_duration`, `http_request_duration`, and `http_response_size` so we can compare latency, failures, and status codes (including timeouts) during the dual readiness-mode rollout.
- Plumb the chosen readiness mode from `waitForReady` via a request-scoped tracker.
- Leave TODOs to remove the label (and related mode metrics) once a default readiness mode is decided.

## Test plan
- [x] `go test ./pkg/service/ ./pkg/api/ ./pkg/api/middleware/ -count=1`
- [x] Run renderer locally, scrape `/metrics` after `/healthz` → `mode="unknown"`
- [x] Successful PDF render from Grafana → `mode="binding"` on render/HTTP duration metrics and `browser_readiness_mode_total{mode="binding"}`


Made with [Cursor](https://cursor.com)