### PR TITLE
Fix: align OTel semconv with SDK to prevent tracing startup crash

### DIFF
--- a/pkg/traces/traces.go
+++ b/pkg/traces/traces.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/credentials"

--- a/pkg/traces/traces_test.go
+++ b/pkg/traces/traces_test.go
@@ -1,0 +1,24 @@
+package traces
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+)
+
+// resource.Default() and our service attributes must share a schema URL;
+// resource.Merge rejects mismatches (startup crash when tracing.endpoint is set).
+func TestResourceMergeMatchesSDKSchema(t *testing.T) {
+	t.Parallel()
+
+	_, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName("grafana-image-renderer"),
+		),
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- Bump `pkg/traces` from `semconv/v1.40.0` to `v1.41.0` so it matches `otel/sdk` v1.44.0 `resource.Default()` schema.
- Add a regression test that `resource.Merge` succeeds with the SDK default resource.

In v5.11.0, `resource.Merge` fails on schema mismatch when `tracing.endpoint` is configured, so tracer setup crashes at startup. Users with tracing enabled should skip v5.11.0 and use the following patch release once available.

## Test plan
- [x] `go test ./pkg/traces/ -count=1`
- [ ] Start the service with `tracing.endpoint` set and confirm startup succeeds
- [ ] Tag/release a patch after merge