### PR TITLE
Browser: add max page-scale-factor (default 4)

### DIFF
--- a/docs/sources/flags.md
+++ b/docs/sources/flags.md
@@ -62,6 +62,8 @@ This is a verbatim copy of the output of the `grafana-image-renderer server --he
     Headers to add to every request the browser makes. Syntax is `${key}=${value}`. May be repeated. [config: browser.header]
 --browser.max-height=<int> [default: 3000] [${BROWSER_MAX_HEIGHT}]
     The maximum height of the browser viewport. Requests cannot request a larger height than this, except for when capturing full-page screenshots. Negative means ignored. [config: browser.max-height]
+--browser.max-page-scale-factor=<float> [default: 4] [${BROWSER_MAX_PAGE_SCALE_FACTOR}]
+    The maximum page scale factor of the browser. Requests cannot request a larger scale than this. Negative means ignored. [config: browser.max-page-scale-factor]
 --browser.max-width=<int> [default: 3000] [${BROWSER_MAX_WIDTH}]
     The maximum width of the browser viewport. Requests cannot request a larger width than this. Negative means ignored. [config: browser.max-width]
 --browser.min-height=<int> [default: 500] [${BROWSER_MIN_HEIGHT}]

--- a/docs/sources/flags.md
+++ b/docs/sources/flags.md
@@ -63,7 +63,7 @@ This is a verbatim copy of the output of the `grafana-image-renderer server --he
 --browser.max-height=<int> [default: 3000] [${BROWSER_MAX_HEIGHT}]
     The maximum height of the browser viewport. Requests cannot request a larger height than this, except for when capturing full-page screenshots. Negative means ignored. [config: browser.max-height]
 --browser.max-page-scale-factor=<float> [default: 4] [${BROWSER_MAX_PAGE_SCALE_FACTOR}]
-    The maximum page scale factor of the browser. Requests cannot request a larger scale than this. Negative means ignored. [config: browser.max-page-scale-factor]
+    The maximum page scale factor of the browser. Requests cannot request a larger scale than this. [config: browser.max-page-scale-factor]
 --browser.max-width=<int> [default: 3000] [${BROWSER_MAX_WIDTH}]
     The maximum width of the browser viewport. Requests cannot request a larger width than this. Negative means ignored. [config: browser.max-width]
 --browser.min-height=<int> [default: 500] [${BROWSER_MIN_HEIGHT}]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -441,9 +441,14 @@ type RequestConfig struct {
 	// MaxHeight is the maximum height of the browser viewport.
 	// A request cannot request a larger browser viewport than this, except for when capturing full-page screenshots.
 	// If negative, it is ignored.
-	MaxHeight       int
+	MaxHeight int
+	// PageScaleFactor is the default page/device scale factor used for rendering.
 	PageScaleFactor float64
-	Landscape       bool
+	// MaxPageScaleFactor is the maximum page/device scale factor a request may use.
+	// Requests that ask for a larger scale are clamped to this value.
+	// If negative, it is ignored.
+	MaxPageScaleFactor float64
+	Landscape          bool
 
 	// Readiness properties are a "best guess" configuration for waiting for the page to be ready for capture
 	// ReadinessTimeout is the maximum time to wait for the web-page to become ready (i.e. no longer loading anything).
@@ -709,6 +714,24 @@ func BrowserFlags() []cli.Flag {
 			Usage:   "The page scale factor of the browser. [config: browser.page-scale-factor]",
 			Value:   1.0,
 			Sources: FromConfig("browser.page-scale-factor", "BROWSER_PAGE_SCALE_FACTOR"),
+			Validator: func(f float64) error {
+				if f <= 0 {
+					return fmt.Errorf("browser page-scale-factor must be positive")
+				}
+				return nil
+			},
+		},
+		&cli.Float64Flag{
+			Name:    "browser.max-page-scale-factor",
+			Usage:   "The maximum page scale factor of the browser. Requests cannot request a larger scale than this. Negative means ignored. [config: browser.max-page-scale-factor]",
+			Value:   4.0,
+			Sources: FromConfig("browser.max-page-scale-factor", "BROWSER_MAX_PAGE_SCALE_FACTOR"),
+			Validator: func(f float64) error {
+				if f >= 0 && f < 0.1 {
+					return fmt.Errorf("browser max-page-scale-factor must be at least 0.1, or negative to be ignored")
+				}
+				return nil
+			},
 		},
 		&cli.BoolFlag{
 			Name:    "browser.portrait",
@@ -736,12 +759,17 @@ func requestConfigFromCommand(c *cli.Command) (RequestConfig, error) {
 	minHeight := c.Int("browser.min-height")
 	maxWidth := c.Int("browser.max-width")
 	maxHeight := c.Int("browser.max-height")
+	pageScaleFactor := c.Float64("browser.page-scale-factor")
+	maxPageScaleFactor := c.Float64("browser.max-page-scale-factor")
 
 	if maxWidth >= 0 && minWidth > maxWidth {
 		return RequestConfig{}, fmt.Errorf("browser min-width (%d) cannot be larger than max-width (%d)", minWidth, maxWidth)
 	}
 	if maxHeight >= 0 && minHeight > maxHeight {
 		return RequestConfig{}, fmt.Errorf("browser min-height (%d) cannot be larger than max-height (%d)", minHeight, maxHeight)
+	}
+	if maxPageScaleFactor > 0 && pageScaleFactor > maxPageScaleFactor {
+		return RequestConfig{}, fmt.Errorf("browser page-scale-factor (%g) cannot be larger than max-page-scale-factor (%g)", pageScaleFactor, maxPageScaleFactor)
 	}
 
 	return RequestConfig{
@@ -750,7 +778,8 @@ func requestConfigFromCommand(c *cli.Command) (RequestConfig, error) {
 		MinHeight:                       minHeight,
 		MaxWidth:                        maxWidth,
 		MaxHeight:                       maxHeight,
-		PageScaleFactor:                 c.Float64("browser.page-scale-factor"),
+		PageScaleFactor:                 pageScaleFactor,
+		MaxPageScaleFactor:              maxPageScaleFactor,
 		Landscape:                       !c.Bool("browser.portrait"),
 		ReadinessTimeout:                c.Duration("browser.readiness.timeout"),
 		ReadinessIterationInterval:      c.Duration("browser.readiness.iteration-interval"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -446,7 +446,7 @@ type RequestConfig struct {
 	PageScaleFactor float64
 	// MaxPageScaleFactor is the maximum page/device scale factor a request may use.
 	// Requests that ask for a larger scale are clamped to this value.
-	// If negative, it is ignored.
+	// Must be positive.
 	MaxPageScaleFactor float64
 	Landscape          bool
 
@@ -723,12 +723,12 @@ func BrowserFlags() []cli.Flag {
 		},
 		&cli.Float64Flag{
 			Name:    "browser.max-page-scale-factor",
-			Usage:   "The maximum page scale factor of the browser. Requests cannot request a larger scale than this. Negative means ignored. [config: browser.max-page-scale-factor]",
+			Usage:   "The maximum page scale factor of the browser. Requests cannot request a larger scale than this. [config: browser.max-page-scale-factor]",
 			Value:   4.0,
 			Sources: FromConfig("browser.max-page-scale-factor", "BROWSER_MAX_PAGE_SCALE_FACTOR"),
 			Validator: func(f float64) error {
-				if f >= 0 && f < 0.1 {
-					return fmt.Errorf("browser max-page-scale-factor must be at least 0.1, or negative to be ignored")
+				if f <= 0 {
+					return fmt.Errorf("browser max-page-scale-factor must be positive")
 				}
 				return nil
 			},
@@ -768,7 +768,7 @@ func requestConfigFromCommand(c *cli.Command) (RequestConfig, error) {
 	if maxHeight >= 0 && minHeight > maxHeight {
 		return RequestConfig{}, fmt.Errorf("browser min-height (%d) cannot be larger than max-height (%d)", minHeight, maxHeight)
 	}
-	if maxPageScaleFactor > 0 && pageScaleFactor > maxPageScaleFactor {
+	if pageScaleFactor > maxPageScaleFactor {
 		return RequestConfig{}, fmt.Errorf("browser page-scale-factor (%g) cannot be larger than max-page-scale-factor (%g)", pageScaleFactor, maxPageScaleFactor)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -744,7 +744,18 @@ func TestMaxPageScaleFactorConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "max-page-scale-factor")
 	})
 
-	t.Run("allows disabling max with negative value", func(t *testing.T) {
+	t.Run("rejects non-positive max", func(t *testing.T) {
+		t.Parallel()
+
+		err := newCmd().Run(t.Context(), []string{
+			"",
+			"--browser.max-page-scale-factor=-1",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max-page-scale-factor")
+	})
+
+	t.Run("allows raising max above default", func(t *testing.T) {
 		t.Parallel()
 
 		var browserConfig BrowserConfig
@@ -762,12 +773,12 @@ func TestMaxPageScaleFactorConfig(t *testing.T) {
 
 		err := cmd.Run(t.Context(), []string{
 			"",
-			"--browser.page-scale-factor=10",
-			"--browser.max-page-scale-factor=-1",
+			"--browser.page-scale-factor=5",
+			"--browser.max-page-scale-factor=5",
 		})
 		require.NoError(t, err)
-		assert.Equal(t, 10.0, browserConfig.DefaultRequestConfig.PageScaleFactor)
-		assert.Equal(t, -1.0, browserConfig.DefaultRequestConfig.MaxPageScaleFactor)
+		assert.Equal(t, 5.0, browserConfig.DefaultRequestConfig.PageScaleFactor)
+		assert.Equal(t, 5.0, browserConfig.DefaultRequestConfig.MaxPageScaleFactor)
 	})
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -101,6 +101,7 @@ func TestRenderRequestConfig(t *testing.T) {
 		MaxWidth:                        3000,
 		MaxHeight:                       3000,
 		PageScaleFactor:                 1.0,
+		MaxPageScaleFactor:              4.0,
 		Landscape:                       true,
 		ReadinessTimeout:                30 * time.Second,
 		ReadinessIterationInterval:      100 * time.Millisecond,
@@ -165,6 +166,7 @@ func TestRenderRequestConfig(t *testing.T) {
 			MaxWidth:                        4000,
 			MaxHeight:                       4000,
 			PageScaleFactor:                 2.0,
+			MaxPageScaleFactor:              4.0,
 			Landscape:                       false,
 			ReadinessTimeout:                60 * time.Second,
 			ReadinessIterationInterval:      200 * time.Millisecond,
@@ -194,6 +196,7 @@ func TestRenderRequestConfig(t *testing.T) {
 		assert.Equal(t, 4000, result.MaxWidth)
 		assert.Equal(t, 4000, result.MaxHeight)
 		assert.Equal(t, 2.0, result.PageScaleFactor)
+		assert.Equal(t, 4.0, result.MaxPageScaleFactor)
 		assert.Equal(t, false, result.Landscape)
 		assert.Equal(t, 60*time.Second, result.ReadinessTimeout)
 		assert.Equal(t, 200*time.Millisecond, result.ReadinessIterationInterval)
@@ -574,6 +577,8 @@ browser:
 			"override should inherit max-height from base")
 		assert.Equal(t, defaultCfg.PageScaleFactor, overrideCfg.PageScaleFactor,
 			"override should inherit page-scale-factor from base (even though it's a default)")
+		assert.Equal(t, defaultCfg.MaxPageScaleFactor, overrideCfg.MaxPageScaleFactor,
+			"override should inherit max-page-scale-factor from base")
 		assert.Equal(t, defaultCfg.Landscape, overrideCfg.Landscape,
 			"override should inherit landscape from base")
 		assert.Equal(t, defaultCfg.TimeBetweenScrolls, overrideCfg.TimeBetweenScrolls,
@@ -633,6 +638,7 @@ func TestOverrideWithOnlyPageScaleFactor(t *testing.T) {
 	assert.Equal(t, 3000, browserConfig.DefaultRequestConfig.MaxWidth, "default MaxWidth")
 	assert.Equal(t, 3000, browserConfig.DefaultRequestConfig.MaxHeight, "default MaxHeight")
 	assert.Equal(t, 1.0, browserConfig.DefaultRequestConfig.PageScaleFactor, "default PageScaleFactor")
+	assert.Equal(t, 4.0, browserConfig.DefaultRequestConfig.MaxPageScaleFactor, "default MaxPageScaleFactor")
 
 	// Override config should also have the SAME default values
 	require.Len(t, browserConfig.RequestConfigOverrides, 1, "expected one override")
@@ -648,6 +654,8 @@ func TestOverrideWithOnlyPageScaleFactor(t *testing.T) {
 		"override should have same MaxHeight as default")
 	assert.Equal(t, browserConfig.DefaultRequestConfig.PageScaleFactor, override.Config.PageScaleFactor,
 		"override should have same PageScaleFactor as default")
+	assert.Equal(t, browserConfig.DefaultRequestConfig.MaxPageScaleFactor, override.Config.MaxPageScaleFactor,
+		"override should have same MaxPageScaleFactor as default")
 	assert.Equal(t, browserConfig.DefaultRequestConfig.TimeBetweenScrolls, override.Config.TimeBetweenScrolls,
 		"override should have same TimeBetweenScrolls as default")
 	assert.Equal(t, browserConfig.DefaultRequestConfig.Landscape, override.Config.Landscape,
@@ -684,6 +692,83 @@ func TestEagerConfigValidation(t *testing.T) {
 		"--browser.override=^https://example\\.com/.*=--browser.readiness.timeout=60s",
 	})
 	require.NoError(t, err)
+}
+
+func TestMaxPageScaleFactorConfig(t *testing.T) {
+	t.Parallel()
+
+	newCmd := func() *cli.Command {
+		return &cli.Command{
+			Flags: BrowserFlags(),
+			Action: func(ctx context.Context, c *cli.Command) error {
+				_, err := BrowserConfigFromCommand(c)
+				return err
+			},
+			Reader:    nopReader{},
+			Writer:    nopWriter{},
+			ErrWriter: nopWriter{},
+		}
+	}
+
+	t.Run("default max is 4", func(t *testing.T) {
+		t.Parallel()
+
+		var browserConfig BrowserConfig
+		cmd := &cli.Command{
+			Flags: BrowserFlags(),
+			Action: func(ctx context.Context, c *cli.Command) error {
+				var err error
+				browserConfig, err = BrowserConfigFromCommand(c)
+				return err
+			},
+			Reader:    nopReader{},
+			Writer:    nopWriter{},
+			ErrWriter: nopWriter{},
+		}
+
+		err := cmd.Run(t.Context(), []string{""})
+		require.NoError(t, err)
+		assert.Equal(t, 4.0, browserConfig.DefaultRequestConfig.MaxPageScaleFactor)
+	})
+
+	t.Run("rejects page-scale-factor above max", func(t *testing.T) {
+		t.Parallel()
+
+		err := newCmd().Run(t.Context(), []string{
+			"",
+			"--browser.page-scale-factor=5",
+			"--browser.max-page-scale-factor=4",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "page-scale-factor")
+		assert.Contains(t, err.Error(), "max-page-scale-factor")
+	})
+
+	t.Run("allows disabling max with negative value", func(t *testing.T) {
+		t.Parallel()
+
+		var browserConfig BrowserConfig
+		cmd := &cli.Command{
+			Flags: BrowserFlags(),
+			Action: func(ctx context.Context, c *cli.Command) error {
+				var err error
+				browserConfig, err = BrowserConfigFromCommand(c)
+				return err
+			},
+			Reader:    nopReader{},
+			Writer:    nopWriter{},
+			ErrWriter: nopWriter{},
+		}
+
+		err := cmd.Run(t.Context(), []string{
+			"",
+			"--browser.page-scale-factor=10",
+			"--browser.max-page-scale-factor=-1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 10.0, browserConfig.DefaultRequestConfig.PageScaleFactor)
+		assert.Equal(t, -1.0, browserConfig.DefaultRequestConfig.MaxPageScaleFactor)
+	})
 }
 
 func TestParseOverrideFlags(t *testing.T) {

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -209,6 +209,9 @@ func WithViewport(width, height int) RenderingOption {
 }
 
 // WithPageScaleFactor uses the given scale for all webpages visited by the browser.
+//
+// If the factor is larger than MaxPageScaleFactor (from the config), it is clamped to that maximum.
+// A negative MaxPageScaleFactor means no maximum is applied.
 func WithPageScaleFactor(factor float64) RenderingOption {
 	return func(cfg config.BrowserConfig) (config.BrowserConfig, error) {
 		if factor <= 0 {
@@ -216,7 +219,11 @@ func WithPageScaleFactor(factor float64) RenderingOption {
 		}
 
 		cfg.ApplyAll(func(rc *config.RequestConfig) {
-			rc.PageScaleFactor = factor
+			if rc.MaxPageScaleFactor > 0 && factor > rc.MaxPageScaleFactor {
+				rc.PageScaleFactor = rc.MaxPageScaleFactor
+			} else {
+				rc.PageScaleFactor = factor
+			}
 		})
 
 		return cfg, nil

--- a/pkg/service/browser.go
+++ b/pkg/service/browser.go
@@ -211,7 +211,6 @@ func WithViewport(width, height int) RenderingOption {
 // WithPageScaleFactor uses the given scale for all webpages visited by the browser.
 //
 // If the factor is larger than MaxPageScaleFactor (from the config), it is clamped to that maximum.
-// A negative MaxPageScaleFactor means no maximum is applied.
 func WithPageScaleFactor(factor float64) RenderingOption {
 	return func(cfg config.BrowserConfig) (config.BrowserConfig, error) {
 		if factor <= 0 {
@@ -219,7 +218,7 @@ func WithPageScaleFactor(factor float64) RenderingOption {
 		}
 
 		cfg.ApplyAll(func(rc *config.RequestConfig) {
-			if rc.MaxPageScaleFactor > 0 && factor > rc.MaxPageScaleFactor {
+			if factor > rc.MaxPageScaleFactor {
 				rc.PageScaleFactor = rc.MaxPageScaleFactor
 			} else {
 				rc.PageScaleFactor = factor

--- a/pkg/service/browser_test.go
+++ b/pkg/service/browser_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/chromedp/cdproto/network"
+	"github.com/grafana/grafana-image-renderer/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldTrackReadinessNetworkRequest(t *testing.T) {
@@ -110,4 +112,68 @@ func TestReadinessNetworkObserverIgnoresUntrackedRequests(t *testing.T) {
 
 	observer.onRequestCompleted(network.RequestID("blob-1"))
 	assert.Equal(t, int64(0), observer.inflight())
+}
+
+func TestWithPageScaleFactorClampsToMax(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clamps when above max", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.BrowserConfig{
+			DefaultRequestConfig: config.RequestConfig{
+				PageScaleFactor:    1.0,
+				MaxPageScaleFactor: 4.0,
+			},
+		}
+
+		updated, err := WithPageScaleFactor(10)(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 4.0, updated.DefaultRequestConfig.PageScaleFactor)
+	})
+
+	t.Run("keeps requested value when within max", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.BrowserConfig{
+			DefaultRequestConfig: config.RequestConfig{
+				PageScaleFactor:    1.0,
+				MaxPageScaleFactor: 4.0,
+			},
+		}
+
+		updated, err := WithPageScaleFactor(2)(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 2.0, updated.DefaultRequestConfig.PageScaleFactor)
+	})
+
+	t.Run("ignores max when negative", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.BrowserConfig{
+			DefaultRequestConfig: config.RequestConfig{
+				PageScaleFactor:    1.0,
+				MaxPageScaleFactor: -1,
+			},
+		}
+
+		updated, err := WithPageScaleFactor(10)(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 10.0, updated.DefaultRequestConfig.PageScaleFactor)
+	})
+
+	t.Run("rejects non-positive factor", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.BrowserConfig{
+			DefaultRequestConfig: config.RequestConfig{
+				PageScaleFactor:    1.0,
+				MaxPageScaleFactor: 4.0,
+			},
+		}
+
+		_, err := WithPageScaleFactor(0)(cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidBrowserOption)
+	})
 }

--- a/pkg/service/browser_test.go
+++ b/pkg/service/browser_test.go
@@ -147,19 +147,19 @@ func TestWithPageScaleFactorClampsToMax(t *testing.T) {
 		assert.Equal(t, 2.0, updated.DefaultRequestConfig.PageScaleFactor)
 	})
 
-	t.Run("ignores max when negative", func(t *testing.T) {
+	t.Run("clamps to a raised max", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := config.BrowserConfig{
 			DefaultRequestConfig: config.RequestConfig{
 				PageScaleFactor:    1.0,
-				MaxPageScaleFactor: -1,
+				MaxPageScaleFactor: 5.0,
 			},
 		}
 
 		updated, err := WithPageScaleFactor(10)(cfg)
 		require.NoError(t, err)
-		assert.Equal(t, 10.0, updated.DefaultRequestConfig.PageScaleFactor)
+		assert.Equal(t, 5.0, updated.DefaultRequestConfig.PageScaleFactor)
 	})
 
 	t.Run("rejects non-positive factor", func(t *testing.T) {

--- a/tests/acceptance/rendering_grafana_test.go
+++ b/tests/acceptance/rendering_grafana_test.go
@@ -43,7 +43,10 @@ func TestRenderingGrafana(t *testing.T) {
 		testcontainers.CleanupNetwork(t, net)
 
 		StartPrometheus(t, WithNetwork(net, "prometheus"))
-		svc := StartImageRenderer(t, WithNetwork(net, "gir"), WithEnv("BROWSER_READINESS_TIMEOUT", "60s"))
+		// Allow deviceScaleFactor=5 used by the d-solo scaling subtest (default max is 4).
+		svc := StartImageRenderer(t, WithNetwork(net, "gir"),
+			WithEnv("BROWSER_READINESS_TIMEOUT", "60s"),
+			WithEnv("BROWSER_MAX_PAGE_SCALE_FACTOR", "5"))
 		_ = StartGrafana(t,
 			WithNetwork(net, "grafana"),
 			WithEnv("GF_RENDERING_SERVER_URL", "http://gir:8081/render"),
@@ -705,7 +708,10 @@ func TestRenderingGrafana(t *testing.T) {
 		testcontainers.CleanupNetwork(t, net)
 
 		StartPrometheus(t, WithNetwork(net, "prometheus"))
-		svc := StartImageRenderer(t, WithNetwork(net, "gir"), WithEnv("BROWSER_READINESS_TIMEOUT", "60s"))
+		// Allow deviceScaleFactor=5 used by this test (default max is 4).
+		svc := StartImageRenderer(t, WithNetwork(net, "gir"),
+			WithEnv("BROWSER_READINESS_TIMEOUT", "60s"),
+			WithEnv("BROWSER_MAX_PAGE_SCALE_FACTOR", "5"))
 		_ = StartGrafana(t,
 			WithNetwork(net, "grafana"),
 			WithEnv("GF_RENDERING_SERVER_URL", "http://gir:8081/render"),


### PR DESCRIPTION
## Summary
- Adds `--browser.max-page-scale-factor` / `BROWSER_MAX_PAGE_SCALE_FACTOR` (default **4**), restoring the old Node renderer’s max device scale factor cap.
- Per-request `deviceScaleFactor` values above the max are clamped (same pattern as max width/height).
- The max must be positive — raise it if you need a higher scale; there is no unbounded mode.
- Rejects startup config where `page-scale-factor` is greater than `max-page-scale-factor`.

Fixes #1033 (unbounded `deviceScaleFactor` / scale). The report’s second point about `max-width`/`max-height` vs final pixel size is expected: those limit the CSS viewport; scale is device pixel ratio.

## Test plan
- [x] `go test ./pkg/config/ ./pkg/service/ -count=1`
- [x] Acceptance tests: allow max scale 5 for fixtures that use `deviceScaleFactor=5`
- [ ] Request with `deviceScaleFactor=10` and default config → effective scale is 4
- [ ] Request with `deviceScaleFactor=2` → scale remains 2
- [ ] Start with `--browser.max-page-scale-factor=5 --browser.page-scale-factor=5` → allowed
- [ ] Start with `--browser.page-scale-factor=5 --browser.max-page-scale-factor=4` → fails at startup
- [ ] Start with `--browser.max-page-scale-factor=-1` → fails at startup