### PR TITLE
Dockerfile: bump base image and chromium version for hygiene

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 go build \
   -ldflags '-s -w -extldflags "-static"' \
   .
 
-FROM debian:trixie-20260713@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4 AS output_image
+FROM debian:trixie-20260803@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958 AS output_image
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-07-23' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-08-12' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=150.0.7871.181
+ARG CHROMIUM_VERSION=151.0.7922.108
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
## Summary
- Bump base image pin from `debian:trixie-20260713` to `debian:trixie-20260803` and refresh the cachebuster date, as routine hygiene.
- Bump the `CHROMIUM_VERSION` apt floor from `150.0.7871.181` to `151.0.7922.108`, matching the version currently resolved from `trixie-security`.

Note: this is a hygiene bump, not a vulnerability fix

## Test plan
- [x] `docker build` succeeds with the new base image digest and chromium floor
- [x] Confirmed installed chromium version in the built image is `151.0.7922.108-1~deb13u1`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)