### PR TITLE
Docker: Update Chromium to 151.0.7922.169

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="Grafana team <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana-image-renderer/tree/master/Dockerfile"
 
 # If we ever need to bust the cache, just change the date here.
-RUN echo 'cachebuster 2026-08-12' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
+RUN echo 'cachebuster 2026-08-24' && apt-get update && apt-get upgrade -y --no-install-recommends --no-install-suggests
 
 RUN apt-get install -y --no-install-recommends --no-install-suggests \
   fonts-ipaexfont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst-one fonts-freefont-ttf \
@@ -30,7 +30,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
   bash util-linux openssl tini ca-certificates locales libnss3-tools ca-certificates
 
 # renovate: depName=chromium
-ARG CHROMIUM_VERSION=151.0.7922.108
+ARG CHROMIUM_VERSION=151.0.7922.169
 RUN apt-get satisfy -y --no-install-recommends --no-install-suggests \
   "chromium (>=${CHROMIUM_VERSION}), chromium-driver (>=${CHROMIUM_VERSION}), chromium-shell (>=${CHROMIUM_VERSION}), chromium-sandbox (>=${CHROMIUM_VERSION})"
 


### PR DESCRIPTION
Contains the following security fixes:

```
chromium (151.0.7922.169-1) unstable; urgency=high

  * d/rules: remove optimize_for_size=true on armhf, as it didn't help.
  * d/patches/debianization/rust-disable-debugsym.patch: add patch to
    disable debug symbols for rust libs (to hopefully fix armhf linking).
  * New upstream security release.
    - CVE-2026-76034: Buffer overflow in WebGL. Reported by Google.
    - CVE-2026-76036: Buffer overflow in Dawn. Reported by Google.
    - CVE-2026-76033: Inappropriate implementation in CORS. Reported by Google
    - CVE-2026-76037: Link following in CredentialProvider. Reported by Google
    - CVE-2026-76044: Race condition in USB. Reported by Google.
    - CVE-2026-76039: Incorrect reference resolution in Core.
      Reported by Google.
    - CVE-2026-76040: Use after free in Browser. Reported by Google.
    - CVE-2026-76035: Inappropriate implementation in Media.
      Reported by Google.
    - CVE-2026-76042: Use of uninitialized resource in GPU. Reported by Google
    - CVE-2026-76046: Buffer overflow in ANGLE. Reported by Google.
    - CVE-2026-76043: Incorrect calculation in V8.
      Reported by Raghav Maheshwari.
    - CVE-2026-76041: Information leak in Skia. Reported by Google.
    - CVE-2026-76047: Type confusion in V8. Reported by ywatanabee.
    - CVE-2026-76038: Type confusion in V8. Reported by un3xploitable && GF.
    - CVE-2026-76045: Use after free in WebGL.
      Reported by OpenAI Codex Security (amyb).

 -- Andres Salomon <dilinger@debian.org>  Tue, 18 Aug 2026 22:50:18 -0400

chromium (151.0.7922.137-2) unstable; urgency=high

  [ Andres Salomon ]
  * d/rules: set optimize_for_size=true on armhf in an attempt to not run out
    of memory when linking.

 -- Andres Salomon <dilinger@debian.org>  Thu, 13 Aug 2026 00:04:06 -0400

chromium (151.0.7922.137-1) unstable; urgency=high

  [ Andres Salomon ]
  * d/patches/debianization/pre-gen.patch: Re-enable.
  * New upstream security release.
    - CVE-2026-19556: Use after free in V8. Reported by Jihyeon
      Jeong (Compsec Lab, Seoul National University / Research Intern).
    - CVE-2026-19557: Use after free in TabStrip. Reported by Google.
    - CVE-2026-19558: Use after free in Extensions. Reported by @bean5oup.
    - CVE-2026-19559: Use after free in HTML. Reported by Google.
    - CVE-2026-19560: Use after free in Blink.
      Reported by WinD39 - Huynh Dinh Vu.

 -- Andres Salomon <dilinger@debian.org>  Wed, 12 Aug 2026 02:47:24 -0400
```